### PR TITLE
limit setuptools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             python3 -mvenv /usr/local/share/virtualenvs/tap-deputy
             source /usr/local/share/virtualenvs/tap-deputy/bin/activate
-            pip install -U 'pip<19.2' setuptools
+            pip install -U 'pip<19.2' 'setuptools<51.0.0'
             pip install .[dev]
       - add_ssh_keys
 workflows:


### PR DESCRIPTION
# Description of change
Limit setuptools version so that env will source and tests can run.

# Manual QA steps
 - None
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
