### PR TITLE
Skip discovering Json type fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.1
+ * Skip fields which are of type `Json` during discovery [#9](https://github.com/singer-io/tap-deputy/pull/9)
+
 ## 1.1.0
  * Add support for dev mode [#3](https://github.com/singer-io/tap-deputy/pull/3)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-deputy',
-      version='1.1.0',
+      version='1.1.1',
       description='Singer.io tap for extracting data from the Deputy API',
       author='Deputy',
       url='https://www.deputy.com',

--- a/tap_deputy/discover.py
+++ b/tap_deputy/discover.py
@@ -86,7 +86,8 @@ def get_schema(client, resource_name):
     ]
 
     for field_name, field_type in data['fields'].items():
-        # Skipping all fields of type Json
+        # Skipping all fields of type Json until we decide on how to handle "[]" as null response
+        # Json data fields
         if field_type == "Json":
             continue
         if field_type in ['Date', 'DateTime']:

--- a/tap_deputy/discover.py
+++ b/tap_deputy/discover.py
@@ -86,6 +86,9 @@ def get_schema(client, resource_name):
     ]
 
     for field_name, field_type in data['fields'].items():
+        # Skipping all fields of type Json
+        if field_type == "Json":
+            continue
         if field_type in ['Date', 'DateTime']:
             json_schema = {
                 'type': ['null', 'string'],


### PR DESCRIPTION
# Description of change
Skip discovering all the fields which are of type `Json` until we decide on how to handle `"[]"` response for Json type fields.

#8



# Manual QA steps
 - Did a PR-alpha for 100608 as we don't have integration tests set up for this tap.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
