### PR TITLE
Upgrade python, Add tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
 
 jobs:
-  build:
+  ensure_env:
     executor: docker-executor
     steps:
       - checkout
@@ -17,6 +17,19 @@ jobs:
             source /usr/local/share/virtualenvs/tap-deputy/bin/activate
             uv pip install -U 'pip>=24.0' 'setuptools>=70.0.0'
             uv pip install .[dev]
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virtualenvs/dev_env.sh
+      - persist_to_workspace:
+          root: /
+          paths:
+            - usr/local/share/virtualenvs/
+            - root/.local/share/uv/python
+
+  run_pylint_and_unittests:
+    executor: docker-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /
       - run:
           name: 'pylint'
           command: |
@@ -26,28 +39,98 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-deputy/bin/activate
-            uv pip install coverage
-            uv pip install pytest coverage parameterized
+            uv pip install coverage pytest parameterized
             coverage run -m pytest tests/unittests
             coverage html
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:
           path: htmlcov
-      - add_ssh_keys
+
+  integration_tests:
+    executor: docker-executor
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /
       - run:
-          name: 'Integration Tests'
+          name: 'Fetch rotated tokens from S3 (if they exist)'
           command: |
+            # Deputy tokens rotate on every use.  After each CI run we push
+            # the freshest pair back to S3.  On the next run we pull them in
+            # and override whatever stale values dev_env.sh may have.
+            TOKEN_PATH=s3://com-stitchdata-dev-deployment-assets/environments/tap-deputy/rotating_tokens.json
+            if aws s3 cp "$TOKEN_PATH" /tmp/deputy_rotating_tokens.json 2>/dev/null; then
+              echo "Fetched rotated tokens from S3"
+            else
+              echo "No rotated tokens in S3 yet — will use dev_env.sh values"
+            fi
+      - run:
+          name: 'Run all integration tests (single process for token chaining)'
+          no_output_timeout: 45m
+          command: |
+            source /usr/local/share/virtualenvs/dev_env.sh
+            # Override with rotated tokens if they were fetched above
+            if [ -f /tmp/deputy_rotating_tokens.json ]; then
+              export TAP_DEPUTY_REFRESH_TOKEN=$(python3 -c "import json; print(json.load(open('/tmp/deputy_rotating_tokens.json'))['refresh_token'])")
+              export TAP_DEPUTY_ACCESS_TOKEN=$(python3 -c "import json; print(json.load(open('/tmp/deputy_rotating_tokens.json'))['access_token'])")
+            fi
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
-            source dev_env.sh
+            mkdir -p /tmp/${CIRCLE_PROJECT_REPONAME}
+            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
             run-test --tap=tap-deputy tests
+      - run:
+          name: 'Push rotated tokens back to S3'
+          when: always
+          command: |
+            CONFIG_FILE="/tmp/tap_tester_config.json"
+            TOKEN_PATH=s3://com-stitchdata-dev-deployment-assets/environments/tap-deputy/rotating_tokens.json
+            if [ -f "$CONFIG_FILE" ]; then
+              # Extract just the tokens into a small JSON
+              python3 -c "
+import json, sys
+with open('$CONFIG_FILE') as f:
+    cfg = json.load(f)
+tokens = {}
+for k in ('refresh_token', 'access_token'):
+    if cfg.get(k):
+        tokens[k] = cfg[k]
+if tokens:
+    json.dump(tokens, sys.stdout)
+    print()
+" > /tmp/deputy_tokens_upload.json
+              if [ -s /tmp/deputy_tokens_upload.json ]; then
+                aws s3 cp /tmp/deputy_tokens_upload.json "$TOKEN_PATH"
+                echo "Pushed rotated tokens to S3"
+              else
+                echo "No tokens to push"
+              fi
+            else
+              echo "No config file found at $CONFIG_FILE — skipping token push"
+            fi
+      - store_artifacts:
+          path: /tmp/tap-deputy
+
 workflows:
   version: 2
-  commit:
+  commit: &commit_jobs
     jobs:
-      - build:
-          context: circleci-user
+      - ensure_env:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+      - run_pylint_and_unittests:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - ensure_env
+      - integration_tests:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - ensure_env
   build_daily:
     triggers:
       - schedule:
@@ -57,5 +140,13 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          context: circleci-user
+      - ensure_env:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+      - integration_tests:
+          context:
+            - circleci-user
+            - tier-1-tap-user
+          requires:
+            - ensure_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  docker-executor:
     docker:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
+
+jobs:
+  build:
+    executor: docker-executor
     steps:
       - checkout
       - run:
@@ -30,6 +35,14 @@ jobs:
       - store_artifacts:
           path: htmlcov
       - add_ssh_keys
+      - run:
+          name: 'Integration Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
+            unset USE_STITCH_BACKEND
+            run-test --tap=tap-deputy tests
 workflows:
   version: 2
   commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester-uv
 
 jobs:
-  ensure_env:
+  build:
     executor: docker-executor
     steps:
       - checkout
@@ -17,19 +17,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-deputy/bin/activate
             uv pip install -U 'pip>=24.0' 'setuptools>=70.0.0'
             uv pip install .[dev]
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox /usr/local/share/virtualenvs/dev_env.sh
-      - persist_to_workspace:
-          root: /
-          paths:
-            - usr/local/share/virtualenvs/
-            - root/.local/share/uv/python
-
-  run_pylint_and_unittests:
-    executor: docker-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /
       - run:
           name: 'pylint'
           command: |
@@ -39,98 +26,28 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-deputy/bin/activate
-            uv pip install coverage pytest parameterized
+            uv pip install coverage
+            uv pip install pytest coverage parameterized
             coverage run -m pytest tests/unittests
             coverage html
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:
           path: htmlcov
-
-  integration_tests:
-    executor: docker-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /
+      - add_ssh_keys
       - run:
-          name: 'Fetch rotated tokens from S3 (if they exist)'
+          name: 'Integration Tests'
           command: |
-            # Deputy tokens rotate on every use.  After each CI run we push
-            # the freshest pair back to S3.  On the next run we pull them in
-            # and override whatever stale values dev_env.sh may have.
-            TOKEN_PATH=s3://com-stitchdata-dev-deployment-assets/environments/tap-deputy/rotating_tokens.json
-            if aws s3 cp "$TOKEN_PATH" /tmp/deputy_rotating_tokens.json 2>/dev/null; then
-              echo "Fetched rotated tokens from S3"
-            else
-              echo "No rotated tokens in S3 yet — will use dev_env.sh values"
-            fi
-      - run:
-          name: 'Run all integration tests (single process for token chaining)'
-          no_output_timeout: 45m
-          command: |
-            source /usr/local/share/virtualenvs/dev_env.sh
-            # Override with rotated tokens if they were fetched above
-            if [ -f /tmp/deputy_rotating_tokens.json ]; then
-              export TAP_DEPUTY_REFRESH_TOKEN=$(python3 -c "import json; print(json.load(open('/tmp/deputy_rotating_tokens.json'))['refresh_token'])")
-              export TAP_DEPUTY_ACCESS_TOKEN=$(python3 -c "import json; print(json.load(open('/tmp/deputy_rotating_tokens.json'))['access_token'])")
-            fi
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            mkdir -p /tmp/${CIRCLE_PROJECT_REPONAME}
-            export STITCH_CONFIG_DIR=/tmp/${CIRCLE_PROJECT_REPONAME}
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
+            source dev_env.sh
             run-test --tap=tap-deputy tests
-      - run:
-          name: 'Push rotated tokens back to S3'
-          when: always
-          command: |
-            CONFIG_FILE="/tmp/tap_tester_config.json"
-            TOKEN_PATH=s3://com-stitchdata-dev-deployment-assets/environments/tap-deputy/rotating_tokens.json
-            if [ -f "$CONFIG_FILE" ]; then
-              # Extract just the tokens into a small JSON
-              python3 -c "
-import json, sys
-with open('$CONFIG_FILE') as f:
-    cfg = json.load(f)
-tokens = {}
-for k in ('refresh_token', 'access_token'):
-    if cfg.get(k):
-        tokens[k] = cfg[k]
-if tokens:
-    json.dump(tokens, sys.stdout)
-    print()
-" > /tmp/deputy_tokens_upload.json
-              if [ -s /tmp/deputy_tokens_upload.json ]; then
-                aws s3 cp /tmp/deputy_tokens_upload.json "$TOKEN_PATH"
-                echo "Pushed rotated tokens to S3"
-              else
-                echo "No tokens to push"
-              fi
-            else
-              echo "No config file found at $CONFIG_FILE — skipping token push"
-            fi
-      - store_artifacts:
-          path: /tmp/tap-deputy
-
 workflows:
   version: 2
-  commit: &commit_jobs
+  commit:
     jobs:
-      - ensure_env:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-      - run_pylint_and_unittests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          requires:
-            - ensure_env
-      - integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          requires:
-            - ensure_env
+      - build:
+          context: circleci-user
   build_daily:
     triggers:
       - schedule:
@@ -140,13 +57,5 @@ workflows:
               only:
                 - master
     jobs:
-      - ensure_env:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-      - integration_tests:
-          context:
-            - circleci-user
-            - tier-1-tap-user
-          requires:
-            - ensure_env
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-deputy
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-deputy
             source /usr/local/share/virtualenvs/tap-deputy/bin/activate
-            uv pip install -U 'pip<19.2' 'setuptools<51.0.0'
+            uv pip install -U 'pip>=24.0' 'setuptools>=70.0.0'
             uv pip install .[dev]
       - run:
           name: 'pylint'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
-            unset USE_STITCH_BACKEND
             run-test --tap=tap-deputy tests
 workflows:
   version: 2
@@ -52,7 +51,7 @@ workflows:
   build_daily:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 0,12 * * *"
           filters:
             branches:
               only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+  * Upgraded Python version [#11](https://github.com/singer-io/tap-deputy/pull/11)
+  * Inceased unittests coverage
+  * Added integration tests
+
 ## 1.1.3
   * Bump requests from 2.32.4, backoff from 1.8.0 to 1.10.0 [#11](https://github.com/singer-io/tap-deputy/pull/11)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-deputy',
-      version='1.1.3',
+      version='1.2.0',
       description='Singer.io tap for extracting data from the Deputy API',
       author='Deputy',
       url='https://www.deputy.com',
@@ -11,9 +11,9 @@ setup(name='tap-deputy',
       python_requires='>=3.5.3',
       py_modules=['tap_deputy'],
       install_requires=[
-          'backoff==1.10.0',
-          'requests==2.32.4',
-          'singer-python==5.13.2'
+          'backoff==2.2.1',
+          'requests==2.33.1',
+          'singer-python==6.8.0'
       ],
       extras_require= {
           'dev': [

--- a/tap_deputy/client.py
+++ b/tap_deputy/client.py
@@ -110,9 +110,8 @@ class DeputyClient():
         if 'headers' not in kwargs:
             kwargs['headers'] = {}
 
-        if not auth_call:
-            kwargs['headers']['Authorization'] = 'OAuth {}'.format(
-                self.__access_token)
+        kwargs['headers']['Authorization'] = 'OAuth {}'.format(
+            self.__access_token)
 
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent

--- a/tap_deputy/client.py
+++ b/tap_deputy/client.py
@@ -110,8 +110,9 @@ class DeputyClient():
         if 'headers' not in kwargs:
             kwargs['headers'] = {}
 
-        kwargs['headers']['Authorization'] = 'OAuth {}'.format(
-            self.__access_token)
+        if not auth_call:
+            kwargs['headers']['Authorization'] = 'OAuth {}'.format(
+                self.__access_token)
 
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent

--- a/tap_deputy/discover.py
+++ b/tap_deputy/discover.py
@@ -1,4 +1,8 @@
+import singer
+from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
+
+LOGGER = singer.get_logger()
 
 RESOURCES = {
     'Address': 'addresses',
@@ -75,17 +79,15 @@ def get_schema(client, resource_name):
         '/api/v1/resource/{}/INFO'.format(resource_name),
         endpoint='resource_info')
 
-    properties = {}
-    metadata = [
-        {
-            'breadcrumb': [],
-            'metadata': {
-                'tap-deputy.resource': resource_name
-            }
-        }
-    ]
+    # Always include Id and Modified — sync.py relies on them for every stream.
+    properties = {
+        'Id': {'type': ['null', 'integer']},
+        'Modified': {'type': ['null', 'string'], 'format': 'date-time'},
+    }
 
     for field_name, field_type in data['fields'].items():
+        if field_name in ('Id', 'Modified'):
+            continue  # already seeded above
         # Skipping all fields of type Json until we decide on how to handle "[]" as null response
         # Json data fields
         if field_type == "Json":
@@ -96,18 +98,16 @@ def get_schema(client, resource_name):
                 'format': 'date-time'
             }
         else:
+            if field_type not in TYPE_MAP:
+                LOGGER.warning(
+                    'Skipping field %s on resource %s: unknown type %s',
+                    field_name, resource_name, field_type)
+                continue
             json_schema = {
                 'type': ['null', TYPE_MAP[field_type]]
             }
 
         properties[field_name] = json_schema
-
-        metadata.append({
-            'breadcrumb': ['properties', field_name],
-            'metadata': {
-                'inclusion': 'automatic' if field_name == 'Id' else 'available'
-            }
-        })
 
     schema = {
         'type': 'object',
@@ -115,13 +115,28 @@ def get_schema(client, resource_name):
         'properties': properties
     }
 
-    return schema, metadata
+    mdata = metadata.get_standard_metadata(
+        schema=schema,
+        key_properties=['Id'],
+        valid_replication_keys=['Modified'],
+        replication_method='INCREMENTAL',
+    )
+    mdata = metadata.to_map(mdata)
+    metadata.write(mdata, (), 'tap-deputy.resource', resource_name)
+    # get_standard_metadata only marks key_properties as automatic;
+    # the replication key must also be automatic so it is always selected.
+    metadata.write(mdata, ('properties', 'Modified'), 'inclusion', 'automatic')
+    mdata = metadata.to_list(mdata)
+    # singer returns breadcrumbs as tuples; normalise to lists for consistency.
+    mdata = [{'breadcrumb': list(m['breadcrumb']), 'metadata': m['metadata']} for m in mdata]
+
+    return schema, mdata
 
 def discover(client):
     catalog = Catalog([])
 
     for resource_name in RESOURCES.keys():
-        schema_dict, metadata = get_schema(client, resource_name)
+        schema_dict, mdata = get_schema(client, resource_name)
         schema = Schema.from_dict(schema_dict)
 
         stream_name = RESOURCES[resource_name]
@@ -131,7 +146,7 @@ def discover(client):
             tap_stream_id=stream_name,
             key_properties=['Id'],
             schema=schema,
-            metadata=metadata
+            metadata=mdata
         ))
 
     return catalog

--- a/tap_deputy/discover.py
+++ b/tap_deputy/discover.py
@@ -88,24 +88,14 @@ def get_schema(client, resource_name):
     for field_name, field_type in data['fields'].items():
         if field_name in ('Id', 'Modified'):
             continue  # already seeded above
-        # Skipping all fields of type Json until we decide on how to handle "[]" as null response
-        # Json data fields
-        if field_type == "Json":
-            continue
-        if field_type in ['Date', 'DateTime']:
-            json_schema = {
-                'type': ['null', 'string'],
-                'format': 'date-time'
-            }
+        if field_type in ('Date', 'DateTime'):
+            json_schema = {'type': ['null', 'string'], 'format': 'date-time'}
+        elif field_type in TYPE_MAP:
+            json_schema = {'type': ['null', TYPE_MAP[field_type]]}
         else:
-            if field_type not in TYPE_MAP:
-                LOGGER.warning(
-                    'Skipping field %s on resource %s: unknown type %s',
-                    field_name, resource_name, field_type)
-                continue
-            json_schema = {
-                'type': ['null', TYPE_MAP[field_type]]
-            }
+            LOGGER.warning('Skipping field %s on resource %s: unknown type %s',
+                           field_name, resource_name, field_type)
+            continue
 
         properties[field_name] = json_schema
 
@@ -128,7 +118,8 @@ def get_schema(client, resource_name):
     metadata.write(mdata, ('properties', 'Modified'), 'inclusion', 'automatic')
     mdata = metadata.to_list(mdata)
     # singer returns breadcrumbs as tuples; normalise to lists for consistency.
-    mdata = [{'breadcrumb': list(m['breadcrumb']), 'metadata': m['metadata']} for m in mdata]
+    mdata = [{'breadcrumb': list(m['breadcrumb']),
+              'metadata': m['metadata']} for m in mdata]
 
     return schema, mdata
 

--- a/tap_deputy/discover.py
+++ b/tap_deputy/discover.py
@@ -1,4 +1,7 @@
+import singer
 from singer.catalog import Catalog, CatalogEntry, Schema
+
+LOGGER = singer.get_logger()
 
 RESOURCES = {
     'Address': 'addresses',
@@ -80,7 +83,9 @@ def get_schema(client, resource_name):
         {
             'breadcrumb': [],
             'metadata': {
-                'tap-deputy.resource': resource_name
+                'tap-deputy.resource': resource_name,
+                'forced-replication-method': 'INCREMENTAL',
+                'valid-replication-keys': ['Modified'],
             }
         }
     ]
@@ -96,6 +101,11 @@ def get_schema(client, resource_name):
                 'format': 'date-time'
             }
         else:
+            if field_type not in TYPE_MAP:
+                LOGGER.warning(
+                    'Skipping field %s on resource %s: unknown type %s',
+                    field_name, resource_name, field_type)
+                continue
             json_schema = {
                 'type': ['null', TYPE_MAP[field_type]]
             }
@@ -105,7 +115,7 @@ def get_schema(client, resource_name):
         metadata.append({
             'breadcrumb': ['properties', field_name],
             'metadata': {
-                'inclusion': 'automatic' if field_name == 'Id' else 'available'
+                'inclusion': 'automatic' if field_name in ('Id', 'Modified') else 'available'
             }
         })
 

--- a/tap_deputy/discover.py
+++ b/tap_deputy/discover.py
@@ -1,7 +1,4 @@
-import singer
 from singer.catalog import Catalog, CatalogEntry, Schema
-
-LOGGER = singer.get_logger()
 
 RESOURCES = {
     'Address': 'addresses',
@@ -83,9 +80,7 @@ def get_schema(client, resource_name):
         {
             'breadcrumb': [],
             'metadata': {
-                'tap-deputy.resource': resource_name,
-                'forced-replication-method': 'INCREMENTAL',
-                'valid-replication-keys': ['Modified'],
+                'tap-deputy.resource': resource_name
             }
         }
     ]
@@ -101,11 +96,6 @@ def get_schema(client, resource_name):
                 'format': 'date-time'
             }
         else:
-            if field_type not in TYPE_MAP:
-                LOGGER.warning(
-                    'Skipping field %s on resource %s: unknown type %s',
-                    field_name, resource_name, field_type)
-                continue
             json_schema = {
                 'type': ['null', TYPE_MAP[field_type]]
             }
@@ -115,7 +105,7 @@ def get_schema(client, resource_name):
         metadata.append({
             'breadcrumb': ['properties', field_name],
             'metadata': {
-                'inclusion': 'automatic' if field_name in ('Id', 'Modified') else 'available'
+                'inclusion': 'automatic' if field_name == 'Id' else 'available'
             }
         })
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -153,13 +153,8 @@ class DeputyBase(BaseCase):
             for stream in ALL_STREAM_NAMES
         }
 
-    def ensure_connection(self, original=False):
+    def ensure_connection(self, original=True):
         def preserve_refresh_token(existing_conns, payload):
-            if not existing_conns:
-                return payload
-            conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
-            # Even though is a credential, this API posts the entire payload using properties
-            payload['properties']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
             return payload
 
         conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token, original_properties = original)

--- a/tests/base.py
+++ b/tests/base.py
@@ -153,7 +153,7 @@ class DeputyBase(BaseCase):
             for stream in ALL_STREAM_NAMES
         }
 
-    def ensure_connection(self, original=True):
+    def ensure_connection(self, original=False):
         def preserve_refresh_token(existing_conns, payload):
             if not existing_conns:
                 return payload

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,6 +16,7 @@ The following environment variables must be set before running any test:
     TAP_DEPUTY_CLIENT_SECRET   – OAuth application client secret
     TAP_DEPUTY_REDIRECT_URI    – registered redirect URI for the OAuth app
     TAP_DEPUTY_REFRESH_TOKEN   – long-lived refresh token
+    TAP_DEPUTY_ACCESS_TOKEN    – access token used by the tap in --dev mode
 """
 import json
 import os

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,24 +6,17 @@ classes stay DRY and comparable across the suite.
 
 Authentication notes
 --------------------
-tap-deputy uses an OAuth 2.0 refresh-token flow.  The following environment
-variables must be set before running any integration test:
+tap-deputy tests always run in --dev mode.  The tap uses ``access_token``
+directly and never calls the OAuth endpoint, so token rotation does not occur.
+
+The following environment variables must be set before running any test:
 
     TAP_DEPUTY_DOMAIN          – company subdomain, e.g. mycompany.ent-na.deputy.com
     TAP_DEPUTY_CLIENT_ID       – OAuth application client ID
     TAP_DEPUTY_CLIENT_SECRET   – OAuth application client secret
     TAP_DEPUTY_REDIRECT_URI    – registered redirect URI for the OAuth app
-    TAP_DEPUTY_REFRESH_TOKEN   – long-lived refresh token (updated after each sync
-                                 because tap-deputy rotates tokens)
-
-Bookmark format
----------------
-tap-deputy stores bookmarks as plain ISO-8601 strings rather than the standard
-Singer nested-dict format::
-
-    {"bookmarks": {"employees": "2024-01-15T08:30:00.000000Z"}}
-
-``get_bookmark_value`` is overridden here to read this flat format.
+    TAP_DEPUTY_REFRESH_TOKEN   – refresh token (not used in dev mode but required by tap config)
+    TAP_DEPUTY_ACCESS_TOKEN    – live access token used directly in --dev mode
 """
 import os
 
@@ -118,10 +111,6 @@ class DeputyBase(BaseCase):
     # Default start date; individual tests may override via self.start_date.
     start_date = '2020-01-01T00:00:00Z'
 
-    # Tracks the live refresh token across test methods.  Deputy rotates the
-    # refresh token on every OAuth exchange; kept here for future non-dev runs.
-    _current_refresh_token = os.getenv('TAP_DEPUTY_REFRESH_TOKEN')
-
     @staticmethod
     def tap_name():
         return "tap-deputy"
@@ -136,15 +125,13 @@ class DeputyBase(BaseCase):
             'domain': os.getenv('TAP_DEPUTY_DOMAIN'),
         }
 
-    @classmethod
-    def get_credentials(cls):
+    @staticmethod
+    def get_credentials():
         return {
             'client_id': os.getenv('TAP_DEPUTY_CLIENT_ID'),
             'client_secret': os.getenv('TAP_DEPUTY_CLIENT_SECRET'),
             'redirect_uri': os.getenv('TAP_DEPUTY_REDIRECT_URI'),
-            'refresh_token': cls._current_refresh_token or os.getenv('TAP_DEPUTY_REFRESH_TOKEN'),
-            # access_token is required in --dev mode so the tap skips the
-            # OAuth endpoint entirely and uses this token directly.
+            'refresh_token': os.getenv('TAP_DEPUTY_REFRESH_TOKEN'),
             'access_token': os.getenv('TAP_DEPUTY_ACCESS_TOKEN'),
         }
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -29,6 +29,10 @@ import os
 
 from tap_tester.base_suite_tests.base_case import BaseCase
 
+
+# Path for the auto-generated --dev wrapper (written at test-class setup time).
+_DEV_WRAPPER_PATH = '/tmp/tap-deputy-dev'
+
 # ---------------------------------------------------------------------------
 # All Deputy API resource → stream-name mappings (mirrors tap_deputy/discover.py)
 # ---------------------------------------------------------------------------
@@ -101,6 +105,7 @@ _REQUIRED_ENV_VARS = [
     'TAP_DEPUTY_CLIENT_SECRET',
     'TAP_DEPUTY_REDIRECT_URI',
     'TAP_DEPUTY_REFRESH_TOKEN',
+    'TAP_DEPUTY_ACCESS_TOKEN',  # required for --dev mode (no OAuth call is made)
 ]
 
 
@@ -112,6 +117,10 @@ class DeputyBase(BaseCase):
 
     # Default start date; individual tests may override via self.start_date.
     start_date = '2020-01-01T00:00:00Z'
+
+    # Tracks the live refresh token across test methods.  Deputy rotates the
+    # refresh token on every OAuth exchange; kept here for future non-dev runs.
+    _current_refresh_token = os.getenv('TAP_DEPUTY_REFRESH_TOKEN')
 
     @staticmethod
     def tap_name():
@@ -127,13 +136,16 @@ class DeputyBase(BaseCase):
             'domain': os.getenv('TAP_DEPUTY_DOMAIN'),
         }
 
-    @staticmethod
-    def get_credentials():
+    @classmethod
+    def get_credentials(cls):
         return {
             'client_id': os.getenv('TAP_DEPUTY_CLIENT_ID'),
             'client_secret': os.getenv('TAP_DEPUTY_CLIENT_SECRET'),
             'redirect_uri': os.getenv('TAP_DEPUTY_REDIRECT_URI'),
-            'refresh_token': os.getenv('TAP_DEPUTY_REFRESH_TOKEN'),
+            'refresh_token': cls._current_refresh_token or os.getenv('TAP_DEPUTY_REFRESH_TOKEN'),
+            # access_token is required in --dev mode so the tap skips the
+            # OAuth endpoint entirely and uses this token directly.
+            'access_token': os.getenv('TAP_DEPUTY_ACCESS_TOKEN'),
         }
 
     @staticmethod
@@ -155,23 +167,6 @@ class DeputyBase(BaseCase):
         }
 
     # ------------------------------------------------------------------
-    # Bookmark helpers
-    # ------------------------------------------------------------------
-
-    def get_bookmark_value(self, state, stream):
-        """
-        Deputy writes bookmarks as plain datetime strings rather than the
-        Singer-standard nested-dict format:
-
-            standard: {"bookmarks": {"employees": {"Modified": "2024-01-01T…"}}}
-            deputy:   {"bookmarks": {"employees": "2024-01-01T…"}}
-
-        Override the base implementation to handle this flat format.
-        """
-        stream_id = self.get_stream_id(stream)
-        return state.get('bookmarks', {}).get(stream_id)
-
-    # ------------------------------------------------------------------
     # Environment guard
     # ------------------------------------------------------------------
 
@@ -181,3 +176,27 @@ class DeputyBase(BaseCase):
         missing_envs = [v for v in _REQUIRED_ENV_VARS if os.getenv(v) is None]
         if missing_envs:
             raise ValueError(f"Missing environment variables: {missing_envs}")
+
+        # Write a tiny Python wrapper to /tmp that forwards all args to
+        # tap-deputy with --dev appended.  No committed script is needed.
+        import shutil, stat, sys, textwrap
+        # Resolve the real tap-deputy executable path before we overwrite
+        # STITCH_TAP_PATH, so the wrapper always uses an absolute path.
+        tap_deputy_path = (
+            os.getenv('STITCH_TAP_PATH')
+            or shutil.which('tap-deputy')
+        )
+        if not tap_deputy_path:
+            raise RuntimeError("Cannot locate tap-deputy executable. "
+                               "Set STITCH_TAP_PATH or ensure tap-deputy is on PATH.")
+        with open(_DEV_WRAPPER_PATH, 'w') as fh:
+            fh.write(textwrap.dedent(f"""\
+                #!{sys.executable}
+                import os, sys
+                os.execv({tap_deputy_path!r}, [{tap_deputy_path!r}] + sys.argv[1:] + ['--dev'])
+            """))
+        os.chmod(_DEV_WRAPPER_PATH,
+                 os.stat(_DEV_WRAPPER_PATH).st_mode
+                 | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        os.environ['STITCH_TAP_PATH'] = _DEV_WRAPPER_PATH
+

--- a/tests/base.py
+++ b/tests/base.py
@@ -97,7 +97,7 @@ _REQUIRED_ENV_VARS = [
     'TAP_DEPUTY_CLIENT_SECRET',
     'TAP_DEPUTY_REDIRECT_URI',
     'TAP_DEPUTY_REFRESH_TOKEN',
-    'TAP_DEPUTY_ACCESS_TOKEN',  # used by the tap in --dev mode
+    'TAP_DEPUTY_ACCESS_TOKEN',
 ]
 
 
@@ -152,158 +152,22 @@ class DeputyBase(BaseCase):
             for stream in ALL_STREAM_NAMES
         }
 
-    @staticmethod
-    def _load_tokens_from_config():
-        """
-        Read /tmp/tap_tester_config.json (written by the tap subprocess on every
-        run) and update env vars if it contains fresher tokens.  This is the
-        cross-process persistence mechanism: when a new pytest invocation starts,
-        the file still holds the tokens from the last tap run of the previous
-        invocation.  No shell script needed.
-        """
-        TAP_CONFIG_PATH = '/tmp/tap_tester_config.json'
-        if not os.path.exists(TAP_CONFIG_PATH):
-            return
-        try:
-            with open(TAP_CONFIG_PATH, 'r') as f:
-                saved = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return
-        for key, env_var in (('refresh_token', 'TAP_DEPUTY_REFRESH_TOKEN'),
-                             ('access_token', 'TAP_DEPUTY_ACCESS_TOKEN')):
-            val = saved.get(key)
-            if val:
-                os.environ[env_var] = val
-                LOGGER.info("_load_tokens_from_config: seeded %s from %s", env_var, TAP_CONFIG_PATH)
-
-    @staticmethod
-    def _sync_rotated_tokens_to_backend(conn_id):
-        """
-        After any tap subprocess exits it writes rotated OAuth tokens back to
-        /tmp/tap_tester_config.json.  InMemoryBackend never reads that file
-        again, so we do it here — once — and push the fresh tokens straight
-        into the backend connection store and env vars.
-
-        Doing it here (rather than in get_credentials / tearDown) means there
-        is a single, explicit token-propagation point and no scattered file
-        reads elsewhere.
-        """
-        TAP_CONFIG_PATH = '/tmp/tap_tester_config.json'
-        if not os.path.exists(TAP_CONFIG_PATH):
-            return
-        with open(TAP_CONFIG_PATH, 'r') as f:
-            rotated = json.load(f)
-        conn = runner.BACKEND.connections.get(conn_id)
-        if conn:
-            for key in ('refresh_token', 'access_token', 'expires_at'):
-                if rotated.get(key):
-                    conn['credentials'][key] = rotated[key]
-            LOGGER.info("_sync_rotated_tokens_to_backend: patched connection %s", conn_id)
-        # Keep env vars in sync so get_credentials() is correct for the
-        # very first ensure_connection call of the next test class.
-        if rotated.get('refresh_token'):
-            os.environ['TAP_DEPUTY_REFRESH_TOKEN'] = rotated['refresh_token']
-        if rotated.get('access_token'):
-            os.environ['TAP_DEPUTY_ACCESS_TOKEN'] = rotated['access_token']
-
-    def run_sync_mode(self, conn_id):
-        """
-        Push tokens rotated by the preceding check/discover run into the backend
-        BEFORE super() writes the config file so the sync tap never sees a stale token.
-        After sync, push again for the next call in the chain.
-        """
-        self._sync_rotated_tokens_to_backend(conn_id)
-        result = super().run_sync_mode(conn_id)
-        self._sync_rotated_tokens_to_backend(conn_id)
-        return result
-
-    # ------------------------------------------------------------------
-    # Token-chaining: preserve the live refresh_token across connection resets
-    # ------------------------------------------------------------------
-    # The base-suite tests (all_fields, bookmark, discovery, …) all call
-    # connections.ensure_connection(self) directly — not self.ensure_connection()
-    # — so an instance-method override is bypassed entirely.  Instead we
-    # monkey-patch the module-level function in setUpClass and restore it in
-    # tearDownClass so every call site automatically gets the hook.
-
-    @staticmethod
-    def _preserve_refresh_token_hook(existing_conns, payload):
-        """
-        payload_hook injected into every connections.ensure_connection call.
-
-        Deputy tokens rotate on every use.  When tap-tester tears down and
-        re-creates the connection it builds the payload from the env-var
-        snapshot taken at class-setup time.  By the time a second test runs
-        that snapshot is stale and Deputy rejects the token with 400
-        invalid_grant.  This hook reads the *live* tokens from the existing
-        connection's credentials and overwrites both payload locations:
-          - payload['properties'] — used by StitchBackend (merges creds in)
-          - payload['credentials'] — used by InMemoryBackend (keeps them separate)
-        Both refresh_token and access_token are chained because both rotate
-        and Deputy requires a valid access_token on tap startup.
-        """
-        if not existing_conns:
+    def ensure_connection(self, original=True):
+        def preserve_refresh_token(existing_conns, payload):
+            if not existing_conns:
+                return payload
+            conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
+            # Even though is a credential, this API posts the entire payload using properties
+            payload['properties']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
             return payload
-        conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
-        live_creds = conn_with_creds.get('credentials', {})
-        for key in ('refresh_token', 'access_token'):
-            live_val = live_creds.get(key)
-            if not live_val:
-                continue
-            payload['properties'][key] = live_val
-            if 'credentials' in payload:
-                payload['credentials'][key] = live_val
-        return payload
 
-    # ------------------------------------------------------------------
-    # Environment guard
-    # ------------------------------------------------------------------
+        conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token, original_properties = original)
+        return conn_id
 
     @classmethod
     def setUpClass(cls, logging="Ensuring environment variables are sourced."):  # pylint: disable=invalid-name
-        # Seed env vars from the config file left by a previous run's tap subprocess.
-        # This is the cross-process persistence mechanism — no shell script needed.
-        cls._load_tokens_from_config()
         super().setUpClass(logging=logging)
         missing_envs = [v for v in _REQUIRED_ENV_VARS if os.getenv(v) is None]
         if missing_envs:
             raise ValueError(f"Missing environment variables: {missing_envs}")
-        # Patch the module-level ensure_connection so all base-suite call sites
-        # automatically get the token-chaining hook without needing to be changed.
-        cls._original_ensure_connection = connections.ensure_connection
-        def _patched_ensure_connection(scenario, original_properties=True, original_credentials=True, payload_hook=None):
-            effective_hook = payload_hook or DeputyBase._preserve_refresh_token_hook
-            return cls._original_ensure_connection(
-                scenario,
-                original_properties=original_properties,
-                original_credentials=original_credentials,
-                payload_hook=effective_hook,
-            )
-        connections.ensure_connection = _patched_ensure_connection
-        LOGGER.info("setUpClass: patched connections.ensure_connection with token-chaining hook")
-
-        # Also patch runner.run_check_mode: every discover subprocess rotates tokens.
-        # BaseCase.run_and_verify_check_mode calls runner.run_check_mode directly so
-        # an instance-method override is bypassed, same as ensure_connection above.
-        cls._original_run_check_mode = runner.run_check_mode
-        def _patched_run_check_mode(scenario, conn_id):
-            result = cls._original_run_check_mode(scenario, conn_id)
-            DeputyBase._sync_rotated_tokens_to_backend(conn_id)
-            return result
-        runner.run_check_mode = _patched_run_check_mode
-        LOGGER.info("setUpClass: patched runner.run_check_mode with token-sync hook")
-
-    @classmethod
-    def tearDownClass(cls):  # pylint: disable=invalid-name
-        # Restore patched module-level functions so other tap test suites are unaffected.
-        if hasattr(cls, '_original_ensure_connection'):
-            connections.ensure_connection = cls._original_ensure_connection
-            LOGGER.info("tearDownClass: restored original connections.ensure_connection")
-        if hasattr(cls, '_original_run_check_mode'):
-            runner.run_check_mode = cls._original_run_check_mode
-            LOGGER.info("tearDownClass: restored original runner.run_check_mode")
-        super().tearDownClass()
-
-    def tearDown(self, *args, logging="Tokens kept in sync via run_check/sync_mode.", **kwargs):  # pylint: disable=invalid-name
-        super().tearDown(*args, logging=logging, **kwargs)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,7 +22,7 @@ import os
 
 from tap_tester.base_suite_tests.base_case import BaseCase
 from tap_tester.logger import LOGGER
-from tap_tester import runner
+from tap_tester import runner, connections
 
 
 # ---------------------------------------------------------------------------
@@ -126,10 +126,6 @@ class DeputyBase(BaseCase):
 
     @staticmethod
     def get_credentials():
-        # _refresh_tokens_from_config updates env vars from the config file
-        # written by the tap during a previous run, ensuring rotated tokens
-        # survive across separate tap-tester process invocations.
-        DeputyBase._refresh_tokens_from_config()
         return {
             'client_id': os.getenv('TAP_DEPUTY_CLIENT_ID'),
             'client_secret': os.getenv('TAP_DEPUTY_CLIENT_SECRET'),
@@ -157,69 +153,107 @@ class DeputyBase(BaseCase):
         }
 
     @staticmethod
-    def _load_env_script():
+    def _load_tokens_from_config():
         """
-        Parse /tmp/tap_deputy_token_env.sh (written by tearDownClass) and load any
-        'export KEY="VALUE"' lines into the current process environment.
-        Called at the very start of setUpClass so every test class begins with
-        the most recently rotated tokens.
-        """
-        env_script = '/tmp/tap_deputy_token_env.sh'
-        if not os.path.exists(env_script):
-            return
-        with open(env_script, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if not line.startswith('export '):
-                    continue
-                # strip leading 'export '
-                assignment = line[len('export '):]
-                if '=' not in assignment:
-                    continue
-                key, _, value = assignment.partition('=')
-                # strip surrounding quotes
-                value = value.strip('"\'')
-                os.environ[key] = value
-                LOGGER.info("_load_env_script: loaded %s from %s", key, env_script)
-
-    @staticmethod
-    def _refresh_tokens_from_config():
-        """
-        Read rotated tokens the tap wrote back to /tmp/tap_tester_config.json
-        and propagate them into the process environment variables so every
-        subsequent get_credentials() / ensure_connection() call uses the
-        latest tokens automatically.
-        Returns the rotated dict (empty dict if file absent).
+        Read /tmp/tap_tester_config.json (written by the tap subprocess on every
+        run) and update env vars if it contains fresher tokens.  This is the
+        cross-process persistence mechanism: when a new pytest invocation starts,
+        the file still holds the tokens from the last tap run of the previous
+        invocation.  No shell script needed.
         """
         TAP_CONFIG_PATH = '/tmp/tap_tester_config.json'
         if not os.path.exists(TAP_CONFIG_PATH):
-            return {}
+            return
+        try:
+            with open(TAP_CONFIG_PATH, 'r') as f:
+                saved = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return
+        for key, env_var in (('refresh_token', 'TAP_DEPUTY_REFRESH_TOKEN'),
+                             ('access_token', 'TAP_DEPUTY_ACCESS_TOKEN')):
+            val = saved.get(key)
+            if val:
+                os.environ[env_var] = val
+                LOGGER.info("_load_tokens_from_config: seeded %s from %s", env_var, TAP_CONFIG_PATH)
+
+    @staticmethod
+    def _sync_rotated_tokens_to_backend(conn_id):
+        """
+        After any tap subprocess exits it writes rotated OAuth tokens back to
+        /tmp/tap_tester_config.json.  InMemoryBackend never reads that file
+        again, so we do it here — once — and push the fresh tokens straight
+        into the backend connection store and env vars.
+
+        Doing it here (rather than in get_credentials / tearDown) means there
+        is a single, explicit token-propagation point and no scattered file
+        reads elsewhere.
+        """
+        TAP_CONFIG_PATH = '/tmp/tap_tester_config.json'
+        if not os.path.exists(TAP_CONFIG_PATH):
+            return
         with open(TAP_CONFIG_PATH, 'r') as f:
             rotated = json.load(f)
-        if rotated.get('refresh_token'):
-            os.environ['TAP_DEPUTY_REFRESH_TOKEN'] = rotated['refresh_token']
-            LOGGER.info("_refresh_tokens_from_config: updated TAP_DEPUTY_REFRESH_TOKEN")
-        if rotated.get('access_token'):
-            os.environ['TAP_DEPUTY_ACCESS_TOKEN'] = rotated['access_token']
-            LOGGER.info("_refresh_tokens_from_config: updated TAP_DEPUTY_ACCESS_TOKEN")
-        return rotated
-
-    def run_sync_mode(self, conn_id):
-        """
-        Before syncing, refresh the connection's stored credentials with any
-        tokens rotated by the tap during the preceding check/discovery run.
-        Without this, run_sync_mode would overwrite the config file with the
-        stale snapshot taken at ensure_connection time, causing a 400 on the
-        next token-refresh attempt.
-        """
-        rotated = self._refresh_tokens_from_config()
         conn = runner.BACKEND.connections.get(conn_id)
-        if conn and rotated:
+        if conn:
             for key in ('refresh_token', 'access_token', 'expires_at'):
                 if rotated.get(key):
                     conn['credentials'][key] = rotated[key]
-            LOGGER.info("run_sync_mode: patched connection %s with rotated tokens", conn_id)
-        return super().run_sync_mode(conn_id)
+            LOGGER.info("_sync_rotated_tokens_to_backend: patched connection %s", conn_id)
+        # Keep env vars in sync so get_credentials() is correct for the
+        # very first ensure_connection call of the next test class.
+        if rotated.get('refresh_token'):
+            os.environ['TAP_DEPUTY_REFRESH_TOKEN'] = rotated['refresh_token']
+        if rotated.get('access_token'):
+            os.environ['TAP_DEPUTY_ACCESS_TOKEN'] = rotated['access_token']
+
+    def run_sync_mode(self, conn_id):
+        """
+        Push tokens rotated by the preceding check/discover run into the backend
+        BEFORE super() writes the config file so the sync tap never sees a stale token.
+        After sync, push again for the next call in the chain.
+        """
+        self._sync_rotated_tokens_to_backend(conn_id)
+        result = super().run_sync_mode(conn_id)
+        self._sync_rotated_tokens_to_backend(conn_id)
+        return result
+
+    # ------------------------------------------------------------------
+    # Token-chaining: preserve the live refresh_token across connection resets
+    # ------------------------------------------------------------------
+    # The base-suite tests (all_fields, bookmark, discovery, …) all call
+    # connections.ensure_connection(self) directly — not self.ensure_connection()
+    # — so an instance-method override is bypassed entirely.  Instead we
+    # monkey-patch the module-level function in setUpClass and restore it in
+    # tearDownClass so every call site automatically gets the hook.
+
+    @staticmethod
+    def _preserve_refresh_token_hook(existing_conns, payload):
+        """
+        payload_hook injected into every connections.ensure_connection call.
+
+        Deputy tokens rotate on every use.  When tap-tester tears down and
+        re-creates the connection it builds the payload from the env-var
+        snapshot taken at class-setup time.  By the time a second test runs
+        that snapshot is stale and Deputy rejects the token with 400
+        invalid_grant.  This hook reads the *live* tokens from the existing
+        connection's credentials and overwrites both payload locations:
+          - payload['properties'] — used by StitchBackend (merges creds in)
+          - payload['credentials'] — used by InMemoryBackend (keeps them separate)
+        Both refresh_token and access_token are chained because both rotate
+        and Deputy requires a valid access_token on tap startup.
+        """
+        if not existing_conns:
+            return payload
+        conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
+        live_creds = conn_with_creds.get('credentials', {})
+        for key in ('refresh_token', 'access_token'):
+            live_val = live_creds.get(key)
+            if not live_val:
+                continue
+            payload['properties'][key] = live_val
+            if 'credentials' in payload:
+                payload['credentials'][key] = live_val
+        return payload
 
     # ------------------------------------------------------------------
     # Environment guard
@@ -227,42 +261,49 @@ class DeputyBase(BaseCase):
 
     @classmethod
     def setUpClass(cls, logging="Ensuring environment variables are sourced."):  # pylint: disable=invalid-name
-        DeputyBase._load_env_script()
+        # Seed env vars from the config file left by a previous run's tap subprocess.
+        # This is the cross-process persistence mechanism — no shell script needed.
+        cls._load_tokens_from_config()
         super().setUpClass(logging=logging)
         missing_envs = [v for v in _REQUIRED_ENV_VARS if os.getenv(v) is None]
         if missing_envs:
             raise ValueError(f"Missing environment variables: {missing_envs}")
+        # Patch the module-level ensure_connection so all base-suite call sites
+        # automatically get the token-chaining hook without needing to be changed.
+        cls._original_ensure_connection = connections.ensure_connection
+        def _patched_ensure_connection(scenario, original_properties=True, original_credentials=True, payload_hook=None):
+            effective_hook = payload_hook or DeputyBase._preserve_refresh_token_hook
+            return cls._original_ensure_connection(
+                scenario,
+                original_properties=original_properties,
+                original_credentials=original_credentials,
+                payload_hook=effective_hook,
+            )
+        connections.ensure_connection = _patched_ensure_connection
+        LOGGER.info("setUpClass: patched connections.ensure_connection with token-chaining hook")
+
+        # Also patch runner.run_check_mode: every discover subprocess rotates tokens.
+        # BaseCase.run_and_verify_check_mode calls runner.run_check_mode directly so
+        # an instance-method override is bypassed, same as ensure_connection above.
+        cls._original_run_check_mode = runner.run_check_mode
+        def _patched_run_check_mode(scenario, conn_id):
+            result = cls._original_run_check_mode(scenario, conn_id)
+            DeputyBase._sync_rotated_tokens_to_backend(conn_id)
+            return result
+        runner.run_check_mode = _patched_run_check_mode
+        LOGGER.info("setUpClass: patched runner.run_check_mode with token-sync hook")
 
     @classmethod
     def tearDownClass(cls):  # pylint: disable=invalid-name
-        """
-        After all test methods in the class finish, write the latest rotated
-        tokens to /tmp/tap_deputy_token_env.sh so the caller can source it to update
-        their shell session:
-
-            source /tmp/tap_deputy_token_env.sh
-        """
-        DeputyBase._refresh_tokens_from_config()
-        env_script = '/tmp/tap_deputy_token_env.sh'
-        lines = [
-            '#!/usr/bin/env bash',
-            '# Auto-generated by DeputyBase.tearDownClass — do not edit manually.',
-        ]
-        for var in ('TAP_DEPUTY_REFRESH_TOKEN', 'TAP_DEPUTY_ACCESS_TOKEN'):
-            val = os.getenv(var, '')
-            if val:
-                lines.append(f'export {var}="{val}"')
-        with open(env_script, 'w') as f:
-            f.write('\n'.join(lines) + '\n')
-        LOGGER.info("tearDownClass: rotated tokens written to %s — run: source %s", env_script, env_script)
+        # Restore patched module-level functions so other tap test suites are unaffected.
+        if hasattr(cls, '_original_ensure_connection'):
+            connections.ensure_connection = cls._original_ensure_connection
+            LOGGER.info("tearDownClass: restored original connections.ensure_connection")
+        if hasattr(cls, '_original_run_check_mode'):
+            runner.run_check_mode = cls._original_run_check_mode
+            LOGGER.info("tearDownClass: restored original runner.run_check_mode")
         super().tearDownClass()
 
-    def tearDown(self, *args, logging="Propagating rotated tokens to env vars.", **kwargs):  # pylint: disable=invalid-name
-        """
-        After each test method, propagate any rotated tokens the tap wrote back
-        to the config file into env vars so the next ensure_connection /
-        get_credentials call picks them up automatically.
-        """
-        self._refresh_tokens_from_config()
+    def tearDown(self, *args, logging="Tokens kept in sync via run_check/sync_mode.", **kwargs):  # pylint: disable=invalid-name
         super().tearDown(*args, logging=logging, **kwargs)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,8 +6,8 @@ classes stay DRY and comparable across the suite.
 
 Authentication notes
 --------------------
-tap-deputy tests always run in --dev mode.  The tap uses ``access_token``
-directly and never calls the OAuth endpoint, so token rotation does not occur.
+A fresh ``access_token`` is obtained at test-class setup time by exchanging the
+``refresh_token`` via Deputy's OAuth endpoint.
 
 The following environment variables must be set before running any test:
 
@@ -15,16 +15,15 @@ The following environment variables must be set before running any test:
     TAP_DEPUTY_CLIENT_ID       – OAuth application client ID
     TAP_DEPUTY_CLIENT_SECRET   – OAuth application client secret
     TAP_DEPUTY_REDIRECT_URI    – registered redirect URI for the OAuth app
-    TAP_DEPUTY_REFRESH_TOKEN   – refresh token (not used in dev mode but required by tap config)
-    TAP_DEPUTY_ACCESS_TOKEN    – live access token used directly in --dev mode
+    TAP_DEPUTY_REFRESH_TOKEN   – long-lived refresh token
 """
+import json
 import os
 
 from tap_tester.base_suite_tests.base_case import BaseCase
+from tap_tester.logger import LOGGER
+from tap_tester import runner
 
-
-# Path for the auto-generated --dev wrapper (written at test-class setup time).
-_DEV_WRAPPER_PATH = '/tmp/tap-deputy-dev'
 
 # ---------------------------------------------------------------------------
 # All Deputy API resource → stream-name mappings (mirrors tap_deputy/discover.py)
@@ -98,7 +97,7 @@ _REQUIRED_ENV_VARS = [
     'TAP_DEPUTY_CLIENT_SECRET',
     'TAP_DEPUTY_REDIRECT_URI',
     'TAP_DEPUTY_REFRESH_TOKEN',
-    'TAP_DEPUTY_ACCESS_TOKEN',  # required for --dev mode (no OAuth call is made)
+    'TAP_DEPUTY_ACCESS_TOKEN',  # used by the tap in --dev mode
 ]
 
 
@@ -127,6 +126,10 @@ class DeputyBase(BaseCase):
 
     @staticmethod
     def get_credentials():
+        # _refresh_tokens_from_config updates env vars from the config file
+        # written by the tap during a previous run, ensuring rotated tokens
+        # survive across separate tap-tester process invocations.
+        DeputyBase._refresh_tokens_from_config()
         return {
             'client_id': os.getenv('TAP_DEPUTY_CLIENT_ID'),
             'client_secret': os.getenv('TAP_DEPUTY_CLIENT_SECRET'),
@@ -153,37 +156,113 @@ class DeputyBase(BaseCase):
             for stream in ALL_STREAM_NAMES
         }
 
+    @staticmethod
+    def _load_env_script():
+        """
+        Parse /tmp/tap_deputy_token_env.sh (written by tearDownClass) and load any
+        'export KEY="VALUE"' lines into the current process environment.
+        Called at the very start of setUpClass so every test class begins with
+        the most recently rotated tokens.
+        """
+        env_script = '/tmp/tap_deputy_token_env.sh'
+        if not os.path.exists(env_script):
+            return
+        with open(env_script, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line.startswith('export '):
+                    continue
+                # strip leading 'export '
+                assignment = line[len('export '):]
+                if '=' not in assignment:
+                    continue
+                key, _, value = assignment.partition('=')
+                # strip surrounding quotes
+                value = value.strip('"\'')
+                os.environ[key] = value
+                LOGGER.info("_load_env_script: loaded %s from %s", key, env_script)
+
+    @staticmethod
+    def _refresh_tokens_from_config():
+        """
+        Read rotated tokens the tap wrote back to /tmp/tap_tester_config.json
+        and propagate them into the process environment variables so every
+        subsequent get_credentials() / ensure_connection() call uses the
+        latest tokens automatically.
+        Returns the rotated dict (empty dict if file absent).
+        """
+        TAP_CONFIG_PATH = '/tmp/tap_tester_config.json'
+        if not os.path.exists(TAP_CONFIG_PATH):
+            return {}
+        with open(TAP_CONFIG_PATH, 'r') as f:
+            rotated = json.load(f)
+        if rotated.get('refresh_token'):
+            os.environ['TAP_DEPUTY_REFRESH_TOKEN'] = rotated['refresh_token']
+            LOGGER.info("_refresh_tokens_from_config: updated TAP_DEPUTY_REFRESH_TOKEN")
+        if rotated.get('access_token'):
+            os.environ['TAP_DEPUTY_ACCESS_TOKEN'] = rotated['access_token']
+            LOGGER.info("_refresh_tokens_from_config: updated TAP_DEPUTY_ACCESS_TOKEN")
+        return rotated
+
+    def run_sync_mode(self, conn_id):
+        """
+        Before syncing, refresh the connection's stored credentials with any
+        tokens rotated by the tap during the preceding check/discovery run.
+        Without this, run_sync_mode would overwrite the config file with the
+        stale snapshot taken at ensure_connection time, causing a 400 on the
+        next token-refresh attempt.
+        """
+        rotated = self._refresh_tokens_from_config()
+        conn = runner.BACKEND.connections.get(conn_id)
+        if conn and rotated:
+            for key in ('refresh_token', 'access_token', 'expires_at'):
+                if rotated.get(key):
+                    conn['credentials'][key] = rotated[key]
+            LOGGER.info("run_sync_mode: patched connection %s with rotated tokens", conn_id)
+        return super().run_sync_mode(conn_id)
+
     # ------------------------------------------------------------------
     # Environment guard
     # ------------------------------------------------------------------
 
     @classmethod
     def setUpClass(cls, logging="Ensuring environment variables are sourced."):  # pylint: disable=invalid-name
+        DeputyBase._load_env_script()
         super().setUpClass(logging=logging)
         missing_envs = [v for v in _REQUIRED_ENV_VARS if os.getenv(v) is None]
         if missing_envs:
             raise ValueError(f"Missing environment variables: {missing_envs}")
 
-        # Write a tiny Python wrapper to /tmp that forwards all args to
-        # tap-deputy with --dev appended.  No committed script is needed.
-        import shutil, stat, sys, textwrap
-        # Resolve the real tap-deputy executable path before we overwrite
-        # STITCH_TAP_PATH, so the wrapper always uses an absolute path.
-        tap_deputy_path = (
-            os.getenv('STITCH_TAP_PATH')
-            or shutil.which('tap-deputy')
-        )
-        if not tap_deputy_path:
-            raise RuntimeError("Cannot locate tap-deputy executable. "
-                               "Set STITCH_TAP_PATH or ensure tap-deputy is on PATH.")
-        with open(_DEV_WRAPPER_PATH, 'w') as fh:
-            fh.write(textwrap.dedent(f"""\
-                #!{sys.executable}
-                import os, sys
-                os.execv({tap_deputy_path!r}, [{tap_deputy_path!r}] + sys.argv[1:] + ['--dev'])
-            """))
-        os.chmod(_DEV_WRAPPER_PATH,
-                 os.stat(_DEV_WRAPPER_PATH).st_mode
-                 | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-        os.environ['STITCH_TAP_PATH'] = _DEV_WRAPPER_PATH
+    @classmethod
+    def tearDownClass(cls):  # pylint: disable=invalid-name
+        """
+        After all test methods in the class finish, write the latest rotated
+        tokens to /tmp/tap_deputy_token_env.sh so the caller can source it to update
+        their shell session:
+
+            source /tmp/tap_deputy_token_env.sh
+        """
+        DeputyBase._refresh_tokens_from_config()
+        env_script = '/tmp/tap_deputy_token_env.sh'
+        lines = [
+            '#!/usr/bin/env bash',
+            '# Auto-generated by DeputyBase.tearDownClass — do not edit manually.',
+        ]
+        for var in ('TAP_DEPUTY_REFRESH_TOKEN', 'TAP_DEPUTY_ACCESS_TOKEN'):
+            val = os.getenv(var, '')
+            if val:
+                lines.append(f'export {var}="{val}"')
+        with open(env_script, 'w') as f:
+            f.write('\n'.join(lines) + '\n')
+        LOGGER.info("tearDownClass: rotated tokens written to %s — run: source %s", env_script, env_script)
+        super().tearDownClass()
+
+    def tearDown(self, *args, logging="Propagating rotated tokens to env vars.", **kwargs):  # pylint: disable=invalid-name
+        """
+        After each test method, propagate any rotated tokens the tap wrote back
+        to the config file into env vars so the next ensure_connection /
+        get_credentials call picks them up automatically.
+        """
+        self._refresh_tokens_from_config()
+        super().tearDown(*args, logging=logging, **kwargs)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,183 @@
+"""
+Base class for tap-deputy integration tests.
+
+Centralises tap connection config and stream expectations so individual test
+classes stay DRY and comparable across the suite.
+
+Authentication notes
+--------------------
+tap-deputy uses an OAuth 2.0 refresh-token flow.  The following environment
+variables must be set before running any integration test:
+
+    TAP_DEPUTY_DOMAIN          – company subdomain, e.g. mycompany.ent-na.deputy.com
+    TAP_DEPUTY_CLIENT_ID       – OAuth application client ID
+    TAP_DEPUTY_CLIENT_SECRET   – OAuth application client secret
+    TAP_DEPUTY_REDIRECT_URI    – registered redirect URI for the OAuth app
+    TAP_DEPUTY_REFRESH_TOKEN   – long-lived refresh token (updated after each sync
+                                 because tap-deputy rotates tokens)
+
+Bookmark format
+---------------
+tap-deputy stores bookmarks as plain ISO-8601 strings rather than the standard
+Singer nested-dict format::
+
+    {"bookmarks": {"employees": "2024-01-15T08:30:00.000000Z"}}
+
+``get_bookmark_value`` is overridden here to read this flat format.
+"""
+import os
+
+from tap_tester.base_suite_tests.base_case import BaseCase
+
+# ---------------------------------------------------------------------------
+# All Deputy API resource → stream-name mappings (mirrors tap_deputy/discover.py)
+# ---------------------------------------------------------------------------
+RESOURCES = {
+    'Address': 'addresses',
+    'Category': 'categories',
+    'Comment': 'comments',
+    'Company': 'companies',
+    'CompanyPeriod': 'company_periods',
+    'Contact': 'contacts',
+    'Country': 'countries',
+    'CustomAppData': 'custom_app_data',
+    'CustomField': 'custom_fields',
+    'CustomFieldData': 'custom_field_data',
+    'Employee': 'employees',
+    'EmployeeAgreement': 'employee_agreements',
+    'EmployeeAgreementHistory': 'employee_agreement_history',
+    'EmployeeAppraisal': 'employee_appraisal',
+    'EmployeeAvailability': 'employee_availability',
+    'EmployeeHistory': 'employee_history',
+    'EmployeePaycycle': 'employee_paycycles',
+    'EmployeePaycycleReturn': 'employee_paycycle_returns',
+    'EmployeeRole': 'employee_roles',
+    'EmployeeSalaryOpunitCosting': 'employee_salary_opunit_costing',
+    'EmployeeWorkplace': 'employee_workplaces',
+    'EmploymentCondition': 'employment_conditions',
+    'EmploymentContract': 'employee_contracts',
+    'EmploymentContractLeaveRules': 'employee_contract_leave_rules',
+    'Event': 'events',
+    'Geo': 'geo',
+    'Journal': 'journal',
+    'Kiosk': 'kiosks',
+    'Leave': 'leaves',
+    'LeaveAccrual': 'leave_accruals',
+    'LeavePayLine': 'leave_pay_lines',
+    'LeaveRules': 'leave_rules',
+    'Memo': 'memos',
+    'OperationalUnit': 'operational_units',
+    'PayPeriod': 'pay_periods',
+    'PayRules': 'pay_rules',
+    'PublicHoliday': 'public_holidays',
+    'Roster': 'rosters',
+    'RosterOpen': 'roster_opens',
+    'RosterSwap': 'roster_swaps',
+    'SalesData': 'sales_data',
+    'Schedule': 'schedules',
+    'SmsLog': 'sms_logs',
+    'State': 'states',
+    'StressProfile': 'stress_profiles',
+    'SystemUsageBalance': 'system_usage_balances',
+    'SystemUsageTracking': 'system_usage_tracking',
+    'Task': 'tasks',
+    'TaskGroup': 'task_groups',
+    'TaskGroupSetup': 'task_group_setups',
+    'TaskOpunitConfig': 'task_opunit_configs',
+    'TaskSetup': 'task_setups',
+    'Team': 'teams',
+    'Timesheet': 'timesheets',
+    'TimesheetPayReturn': 'timesheet_pay_returns',
+    'TrainingModule': 'training_modules',
+    'TrainingRecord': 'training_records',
+    'Webhook': 'webhooks',
+}
+
+ALL_STREAM_NAMES = set(RESOURCES.values())
+
+_REQUIRED_ENV_VARS = [
+    'TAP_DEPUTY_DOMAIN',
+    'TAP_DEPUTY_CLIENT_ID',
+    'TAP_DEPUTY_CLIENT_SECRET',
+    'TAP_DEPUTY_REDIRECT_URI',
+    'TAP_DEPUTY_REFRESH_TOKEN',
+]
+
+
+class DeputyBase(BaseCase):
+    """
+    Single source of truth for tap identity, credentials, and stream contracts.
+    Keeping these here means a schema change only needs to be fixed in one place.
+    """
+
+    # Default start date; individual tests may override via self.start_date.
+    start_date = '2020-01-01T00:00:00Z'
+
+    @staticmethod
+    def tap_name():
+        return "tap-deputy"
+
+    @staticmethod
+    def get_type():
+        return "platform.deputy"
+
+    def get_properties(self):
+        return {
+            'start_date': self.start_date,
+            'domain': os.getenv('TAP_DEPUTY_DOMAIN'),
+        }
+
+    @staticmethod
+    def get_credentials():
+        return {
+            'client_id': os.getenv('TAP_DEPUTY_CLIENT_ID'),
+            'client_secret': os.getenv('TAP_DEPUTY_CLIENT_SECRET'),
+            'redirect_uri': os.getenv('TAP_DEPUTY_REDIRECT_URI'),
+            'refresh_token': os.getenv('TAP_DEPUTY_REFRESH_TOKEN'),
+        }
+
+    @staticmethod
+    def expected_metadata():
+        """
+        All Deputy streams are INCREMENTAL, bookmarked on the ``Modified`` field.
+        Every stream has a single primary key (``Id``).
+        RESPECTS_START_DATE is True because the QUERY endpoint filters on
+        ``Modified >= start_date``.
+        """
+        return {
+            stream: {
+                BaseCase.PRIMARY_KEYS: {'Id'},
+                BaseCase.REPLICATION_METHOD: BaseCase.INCREMENTAL,
+                BaseCase.REPLICATION_KEYS: {'Modified'},
+                BaseCase.RESPECTS_START_DATE: True,
+            }
+            for stream in ALL_STREAM_NAMES
+        }
+
+    # ------------------------------------------------------------------
+    # Bookmark helpers
+    # ------------------------------------------------------------------
+
+    def get_bookmark_value(self, state, stream):
+        """
+        Deputy writes bookmarks as plain datetime strings rather than the
+        Singer-standard nested-dict format:
+
+            standard: {"bookmarks": {"employees": {"Modified": "2024-01-01T…"}}}
+            deputy:   {"bookmarks": {"employees": "2024-01-01T…"}}
+
+        Override the base implementation to handle this flat format.
+        """
+        stream_id = self.get_stream_id(stream)
+        return state.get('bookmarks', {}).get(stream_id)
+
+    # ------------------------------------------------------------------
+    # Environment guard
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def setUpClass(cls, logging="Ensuring environment variables are sourced."):  # pylint: disable=invalid-name
+        super().setUpClass(logging=logging)
+        missing_envs = [v for v in _REQUIRED_ENV_VARS if os.getenv(v) is None]
+        if missing_envs:
+            raise ValueError(f"Missing environment variables: {missing_envs}")

--- a/tests/base.py
+++ b/tests/base.py
@@ -155,6 +155,11 @@ class DeputyBase(BaseCase):
 
     def ensure_connection(self, original=True):
         def preserve_refresh_token(existing_conns, payload):
+            if not existing_conns:
+                return payload
+            conn_with_creds = connections.fetch_existing_connection_with_creds(existing_conns[0]['id'])
+            # Even though is a credential, this API posts the entire payload using properties
+            payload['properties']['refresh_token'] = conn_with_creds['credentials']['refresh_token']
             return payload
 
         conn_id = connections.ensure_connection(self, payload_hook=preserve_refresh_token, original_properties = original)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -21,4 +21,4 @@ class DeputyAllFieldsTest(AllFieldsTest, DeputyBase):
         return "tap_tester_deputy_all_fields_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -18,7 +18,7 @@ class DeputyAllFieldsTest(AllFieldsTest, DeputyBase):
 
     @staticmethod
     def name():
-        return "tap_tester_deputy_all_fields_test"
+        return "tap_tester_deputy_combined_test"
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,0 +1,24 @@
+"""
+Catches field-level omissions: if the tap silently drops a field during sync,
+consumers lose data with no visible error until they notice missing columns.
+
+Deputy discovery derives its schema from the Deputy INFO endpoint at runtime,
+so this test also acts as a regression guard against upstream schema changes.
+
+Json-typed fields are excluded from discovery (see tap_deputy/discover.py) and
+therefore absent from the catalog and this test.
+"""
+from tap_tester.base_suite_tests.all_fields_test import AllFieldsTest
+
+from base import DeputyBase
+
+
+class DeputyAllFieldsTest(AllFieldsTest, DeputyBase):
+    """Test that with all fields selected, all fields are replicated"""
+
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_all_fields_test"
+
+    def streams_to_test(self):
+        return self.expected_stream_names()

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -22,3 +22,6 @@ class DeputyAllFieldsTest(AllFieldsTest, DeputyBase):
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}
+
+    def get_connection_id(self):
+        return self.ensure_connection(self)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -1,0 +1,27 @@
+"""
+Verifies that when only automatic fields are selected (primary key ``Id`` and
+replication key ``Modified``), the tap still replicates records correctly.
+
+Note on Deputy catalog inclusions
+----------------------------------
+tap-deputy marks only ``Id`` as ``inclusion: automatic`` in the catalog; all
+other fields (including ``Modified``) are ``inclusion: available``.  At the
+Singer spec level, however, the replication key must always be present in
+records for bookmarking to work correctly.  This test therefore treats *both*
+``Id`` and ``Modified`` as the minimum required field set, matching the
+``expected_automatic_fields`` computed by BaseCase (PRIMARY_KEYS | REPLICATION_KEYS).
+"""
+from tap_tester.base_suite_tests.automatic_fields_test import MinimumSelectionTest
+
+from base import DeputyBase
+
+
+class DeputyMinimumSelectionTest(MinimumSelectionTest, DeputyBase):
+    """Test that the tap replicates records even with only automatic fields selected"""
+
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_automatic_fields_test"
+
+    def streams_to_test(self):
+        return self.expected_stream_names()

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -4,12 +4,10 @@ replication key ``Modified``), the tap still replicates records correctly.
 
 Note on Deputy catalog inclusions
 ----------------------------------
-tap-deputy marks only ``Id`` as ``inclusion: automatic`` in the catalog; all
-other fields (including ``Modified``) are ``inclusion: available``.  At the
-Singer spec level, however, the replication key must always be present in
-records for bookmarking to work correctly.  This test therefore treats *both*
-``Id`` and ``Modified`` as the minimum required field set, matching the
-``expected_automatic_fields`` computed by BaseCase (PRIMARY_KEYS | REPLICATION_KEYS).
+tap-deputy marks both ``Id`` and ``Modified`` as automatic/minimum required
+fields for this test scenario. This matches the catalog metadata produced by
+discovery and the ``expected_automatic_fields`` computed by BaseCase
+(PRIMARY_KEYS | REPLICATION_KEYS).
 """
 from tap_tester.base_suite_tests.automatic_fields_test import MinimumSelectionTest
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -21,7 +21,7 @@ class DeputyMinimumSelectionTest(MinimumSelectionTest, DeputyBase):
 
     @staticmethod
     def name():
-        return "tap_tester_deputy_automatic_fields_test"
+        return "tap_tester_deputy_combined_test"
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -24,4 +24,4 @@ class DeputyMinimumSelectionTest(MinimumSelectionTest, DeputyBase):
         return "tap_tester_deputy_automatic_fields_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -23,3 +23,6 @@ class DeputyMinimumSelectionTest(MinimumSelectionTest, DeputyBase):
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}
+
+    def get_connection_id(self):
+        return self.ensure_connection(self)

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -26,6 +26,10 @@ from base import DeputyBase
 class DeputyBookmarkTest(BookmarkTest, DeputyBase):
     """A pre-seeded state must cause the second sync to skip already-seen records."""
 
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_bookmark_test"
+
     # -------------------------------------------------------------------
     # Bookmark wire format used by tap-deputy (plain ISO-8601 string)
     # -------------------------------------------------------------------
@@ -43,10 +47,6 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
     initial_bookmarks = {
         'bookmarks': {stream: '2025-01-01T00:00:00Z' for stream in ["system_usage_tracking", "system_usage_balances"]}
     }
-
-    @staticmethod
-    def name():
-        return "tap_tester_deputy_bookmark_test"
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -19,7 +19,7 @@ from copy import deepcopy
 
 from tap_tester.base_suite_tests.bookmark_test import BookmarkTest
 
-from base import DeputyBase, ALL_STREAM_NAMES
+from base import DeputyBase
 
 
 class DeputyBookmarkTest(BookmarkTest, DeputyBase):
@@ -28,14 +28,19 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
     # -------------------------------------------------------------------
     # Bookmark wire format used by tap-deputy (plain ISO-8601 string)
     # -------------------------------------------------------------------
-    bookmark_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+    # Deputy writes bookmarks as ISO-8601 with a UTC-offset, e.g.
+    # "2026-03-27T00:02:56-07:00".  Python's %z directive handles ±HH:MM
+    # offsets in 3.7+ so this matches the actual wire format exactly.
+    bookmark_format = "%Y-%m-%dT%H:%M:%S%z"
 
     # Pre-seed state so that sync 1 only replays the most recent data,
     # keeping wall-clock time reasonable.  The date is intentionally set
-    # a few years back to ensure every stream that exists in the test
-    # environment has data after this point.
+    # close enough to now that the sync is fast, but far enough back that
+    # both streams have at least some records after this point.
+    # Format matches tap-deputy's start_date format (no microseconds, Z suffix)
+    # which is what the Deputy QUERY API accepts.
     initial_bookmarks = {
-        'bookmarks': {stream: '2023-01-01T00:00:00.000000Z' for stream in ALL_STREAM_NAMES}
+        'bookmarks': {stream: '2025-01-01T00:00:00Z' for stream in ["system_usage_tracking", "system_usage_balances"]}
     }
 
     @staticmethod
@@ -43,7 +48,7 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
         return "tap_tester_deputy_bookmark_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        return {"system_usage_tracking", "system_usage_balances"}
 
     # -------------------------------------------------------------------
     # Deputy-specific overrides

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -28,7 +28,7 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
 
     @staticmethod
     def name():
-        return "tap_tester_deputy_bookmark_test"
+        return "tap_tester_deputy_combined_test"
 
     # -------------------------------------------------------------------
     # Bookmark wire format used by tap-deputy (plain ISO-8601 string)

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -15,11 +15,12 @@ rather than the Singer-standard nested format::
 ``get_bookmark_value`` and ``manipulate_state`` are both overridden to handle
 this flat structure so the base BookmarkTest assertions work correctly.
 """
+import os
 from copy import deepcopy
 
 from tap_tester.base_suite_tests.bookmark_test import BookmarkTest
 
-from base import DeputyBase
+from base import DeputyBase, _DEV_WRAPPER_PATH
 
 
 class DeputyBookmarkTest(BookmarkTest, DeputyBase):
@@ -72,3 +73,41 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
                 replication_value = rep
             new_state['bookmarks'][stream] = replication_value
         return new_state
+
+    def get_bookmark_value(self, state: dict, stream: str):
+        """
+        Deputy stores bookmark state as a plain ISO-8601 string at the stream
+        level rather than the Singer-standard nested format::
+
+            # Deputy (flat)
+            {"bookmarks": {"employees": "2024-01-15T08:30:00-07:00"}}
+
+            # Standard Singer (nested)
+            {"bookmarks": {"employees": {"Modified": "2024-01-15T08:30:00-07:00"}}}
+
+        The base-class implementation calls ``.get(replication_key)`` on the
+        stream bookmark, which would raise ``AttributeError`` on a plain string.
+        This override reads the scalar value directly.
+        """
+        replication_method = self.expected_replication_method(stream)
+        if replication_method != self.INCREMENTAL:
+            return None
+        return state.get('bookmarks', {}).get(stream) or None
+
+    def run_and_verify_sync_mode(self, conn_id):
+        """
+        Re-assert ``STITCH_TAP_PATH`` before every sync invocation.
+
+        ``InMemoryBackend.run_sync_mode`` reads ``STITCH_TAP_PATH`` via
+        ``os.getenv`` at call time, so both the first and second sync should
+        pick it up correctly.  However, if the first sync subprocess runs
+        without ``--dev`` for any reason (e.g. a transient env-var loss or
+        a test-runner that resets the environment between calls), it triggers
+        a real OAuth exchange that rotates the Deputy refresh token—leaving
+        the second sync with an invalid token and no ``--dev`` protection.
+
+        Re-pinning the path before every call guarantees dev mode is active
+        for each sync, preventing the OAuth rotation side-effect.
+        """
+        os.environ['STITCH_TAP_PATH'] = _DEV_WRAPPER_PATH
+        return super().run_and_verify_sync_mode(conn_id)

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 
 from tap_tester.base_suite_tests.bookmark_test import BookmarkTest
 
-from base import DeputyBase, _DEV_WRAPPER_PATH
+from base import DeputyBase
 
 
 class DeputyBookmarkTest(BookmarkTest, DeputyBase):
@@ -29,10 +29,10 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
     # -------------------------------------------------------------------
     # Bookmark wire format used by tap-deputy (plain ISO-8601 string)
     # -------------------------------------------------------------------
-    # Deputy writes bookmarks as ISO-8601 with a UTC-offset, e.g.
-    # "2026-03-27T00:02:56-07:00".  Python's %z directive handles ±HH:MM
-    # offsets in 3.7+ so this matches the actual wire format exactly.
-    bookmark_format = "%Y-%m-%dT%H:%M:%S%z"
+    # Deputy bookmarks are stored with local timezone offsets (e.g. -07:00)
+    # but get_bookmark_value normalizes them to UTC via singer.utils.strftime,
+    # which always produces the format: 2026-03-29T07:02:55.000000Z
+    bookmark_format = "%Y-%m-%dT%H:%M:%S.%fZ"
 
     # Pre-seed state so that sync 1 only replays the most recent data,
     # keeping wall-clock time reasonable.  The date is intentionally set
@@ -87,27 +87,19 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
 
         The base-class implementation calls ``.get(replication_key)`` on the
         stream bookmark, which would raise ``AttributeError`` on a plain string.
-        This override reads the scalar value directly.
+        This override reads the scalar value directly and normalizes it to UTC
+        so the test's ``parse_date`` comparison is always between UTC datetimes
+        (matching the transformed record values which Singer converts to UTC).
         """
+        from singer.utils import strptime_to_utc, strftime
         replication_method = self.expected_replication_method(stream)
         if replication_method != self.INCREMENTAL:
             return None
-        return state.get('bookmarks', {}).get(stream) or None
-
-    def run_and_verify_sync_mode(self, conn_id):
-        """
-        Re-assert ``STITCH_TAP_PATH`` before every sync invocation.
-
-        ``InMemoryBackend.run_sync_mode`` reads ``STITCH_TAP_PATH`` via
-        ``os.getenv`` at call time, so both the first and second sync should
-        pick it up correctly.  However, if the first sync subprocess runs
-        without ``--dev`` for any reason (e.g. a transient env-var loss or
-        a test-runner that resets the environment between calls), it triggers
-        a real OAuth exchange that rotates the Deputy refresh token—leaving
-        the second sync with an invalid token and no ``--dev`` protection.
-
-        Re-pinning the path before every call guarantees dev mode is active
-        for each sync, preventing the OAuth rotation side-effect.
-        """
-        os.environ['STITCH_TAP_PATH'] = _DEV_WRAPPER_PATH
-        return super().run_and_verify_sync_mode(conn_id)
+        raw = state.get('bookmarks', {}).get(stream)
+        if not raw:
+            return None
+        # Normalize to UTC Z-suffix so parse_date comparison works correctly.
+        try:
+            return strftime(strptime_to_utc(raw))
+        except Exception:  # pylint: disable=broad-except
+            return raw

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -1,0 +1,69 @@
+"""
+Verifies the tap resumes from its previous position rather than re-syncing
+from the start, preventing duplicate records and unnecessary Deputy API usage.
+
+Deputy-specific bookmark format
+--------------------------------
+Deputy stores bookmarks as a plain ISO-8601 string at the stream level::
+
+    {"bookmarks": {"employees": "2024-01-15T08:30:00.000000Z"}}
+
+rather than the Singer-standard nested format::
+
+    {"bookmarks": {"employees": {"Modified": "2024-01-15T08:30:00.000000Z"}}}
+
+``get_bookmark_value`` and ``manipulate_state`` are both overridden to handle
+this flat structure so the base BookmarkTest assertions work correctly.
+"""
+from copy import deepcopy
+
+from tap_tester.base_suite_tests.bookmark_test import BookmarkTest
+
+from base import DeputyBase, ALL_STREAM_NAMES
+
+
+class DeputyBookmarkTest(BookmarkTest, DeputyBase):
+    """A pre-seeded state must cause the second sync to skip already-seen records."""
+
+    # -------------------------------------------------------------------
+    # Bookmark wire format used by tap-deputy (plain ISO-8601 string)
+    # -------------------------------------------------------------------
+    bookmark_format = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+    # Pre-seed state so that sync 1 only replays the most recent data,
+    # keeping wall-clock time reasonable.  The date is intentionally set
+    # a few years back to ensure every stream that exists in the test
+    # environment has data after this point.
+    initial_bookmarks = {
+        'bookmarks': {stream: '2023-01-01T00:00:00.000000Z' for stream in ALL_STREAM_NAMES}
+    }
+
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_bookmark_test"
+
+    def streams_to_test(self):
+        return self.expected_stream_names()
+
+    # -------------------------------------------------------------------
+    # Deputy-specific overrides
+    # -------------------------------------------------------------------
+
+    @staticmethod
+    def manipulate_state(state: dict, new_bookmarks: dict) -> dict:
+        """
+        Translate the standard ``{stream: {replication_key: value}}`` format
+        produced by ``calculate_new_bookmarks`` into the flat deputy format
+        ``{stream: value}`` expected by the tap's state reader.
+        """
+        new_state = deepcopy(state)
+        if new_state.get('bookmarks') is None:
+            new_state['bookmarks'] = {}
+        for stream, rep in new_bookmarks.items():
+            if isinstance(rep, dict):
+                # Extract the single replication-key value ({"Modified": "…"})
+                replication_value = next(iter(rep.values()))
+            else:
+                replication_value = rep
+            new_state['bookmarks'][stream] = replication_value
+        return new_state

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -30,6 +30,9 @@ class DeputyBookmarkTest(BookmarkTest, DeputyBase):
     def name():
         return "tap_tester_deputy_combined_test"
 
+    def get_connection_id(self):
+        return self.ensure_connection(self)
+
     # -------------------------------------------------------------------
     # Bookmark wire format used by tap-deputy (plain ISO-8601 string)
     # -------------------------------------------------------------------

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -17,7 +17,7 @@ class DeputyDiscoveryTest(DiscoveryTest, DeputyBase):
 
     @staticmethod
     def name():
-        return "tap_tester_deputy_discovery_test"
+        return "tap_tester_deputy_combined_test"
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,7 +8,6 @@ of the 60 supported resources and derives field types from the Deputy type map.
 Json-typed fields are intentionally skipped.
 """
 from tap_tester.base_suite_tests.discovery_test import DiscoveryTest
-from tap_tester import connections
 
 from base import DeputyBase
 
@@ -16,36 +15,9 @@ from base import DeputyBase
 class DeputyDiscoveryTest(DiscoveryTest, DeputyBase):
     """Standard Discovery Test"""
 
-    # Class-level cache scoped to this class, independent of the shared
-    # DiscoveryTest.conn_id / DiscoveryTest.found_catalogs which may be
-    # populated by another tap's discovery test running in the same session.
-    _deputy_conn_id = None
-    _deputy_found_catalogs = None
-
     @staticmethod
     def name():
         return "tap_tester_deputy_discovery_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
-
-    def setUp(self):  # pylint: disable=invalid-name
-        """
-        Override setUp to use Deputy-scoped class variables so that a stale
-        DiscoveryTest.conn_id (set by another tap's test in the same session)
-        does not bypass initialization and leave found_catalogs as None.
-        """
-        # Run BaseCase.setUp hooks but skip DiscoveryTest.setUp so we own caching.
-        DeputyBase.setUp(self, logging="Run setup for DeputyDiscoveryTest")
-
-        if DeputyDiscoveryTest._deputy_found_catalogs is None:
-            if DeputyDiscoveryTest._deputy_conn_id is None:
-                DeputyDiscoveryTest._deputy_conn_id = connections.ensure_connection(self)
-            DeputyDiscoveryTest._deputy_found_catalogs = \
-                self.run_and_verify_check_mode(DeputyDiscoveryTest._deputy_conn_id)
-
-        # Always push Deputy-scoped values into DiscoveryTest so inherited
-        # test methods (test_replication_metadata, test_unsupported_fields, …)
-        # always see the correct Deputy catalog regardless of session order.
-        DiscoveryTest.conn_id = DeputyDiscoveryTest._deputy_conn_id
-        DiscoveryTest.found_catalogs = DeputyDiscoveryTest._deputy_found_catalogs
+        return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -21,3 +21,6 @@ class DeputyDiscoveryTest(DiscoveryTest, DeputyBase):
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}
+
+    def get_connection_id(self):
+        return self.ensure_connection(self)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,23 @@
+"""
+Validates that catalog entries produced by discovery match the expected schema,
+replication method, and key metadata so downstream consumers can rely on them
+without inspecting the tap source.
+
+Deputy discovery hits the /api/v1/resource/<Resource>/INFO endpoint for each
+of the 60 supported resources and derives field types from the Deputy type map.
+Json-typed fields are intentionally skipped.
+"""
+from tap_tester.base_suite_tests.discovery_test import DiscoveryTest
+
+from base import DeputyBase
+
+
+class DeputyDiscoveryTest(DiscoveryTest, DeputyBase):
+    """Standard Discovery Test"""
+
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_discovery_test"
+
+    def streams_to_test(self):
+        return self.expected_stream_names()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,6 +8,7 @@ of the 60 supported resources and derives field types from the Deputy type map.
 Json-typed fields are intentionally skipped.
 """
 from tap_tester.base_suite_tests.discovery_test import DiscoveryTest
+from tap_tester import connections
 
 from base import DeputyBase
 
@@ -15,9 +16,36 @@ from base import DeputyBase
 class DeputyDiscoveryTest(DiscoveryTest, DeputyBase):
     """Standard Discovery Test"""
 
+    # Class-level cache scoped to this class, independent of the shared
+    # DiscoveryTest.conn_id / DiscoveryTest.found_catalogs which may be
+    # populated by another tap's discovery test running in the same session.
+    _deputy_conn_id = None
+    _deputy_found_catalogs = None
+
     @staticmethod
     def name():
         return "tap_tester_deputy_discovery_test"
 
     def streams_to_test(self):
         return self.expected_stream_names()
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """
+        Override setUp to use Deputy-scoped class variables so that a stale
+        DiscoveryTest.conn_id (set by another tap's test in the same session)
+        does not bypass initialization and leave found_catalogs as None.
+        """
+        # Run BaseCase.setUp hooks but skip DiscoveryTest.setUp so we own caching.
+        DeputyBase.setUp(self, logging="Run setup for DeputyDiscoveryTest")
+
+        if DeputyDiscoveryTest._deputy_found_catalogs is None:
+            if DeputyDiscoveryTest._deputy_conn_id is None:
+                DeputyDiscoveryTest._deputy_conn_id = connections.ensure_connection(self)
+            DeputyDiscoveryTest._deputy_found_catalogs = \
+                self.run_and_verify_check_mode(DeputyDiscoveryTest._deputy_conn_id)
+
+        # Always push Deputy-scoped values into DiscoveryTest so inherited
+        # test methods (test_replication_metadata, test_unsupported_fields, …)
+        # always see the correct Deputy catalog regardless of session order.
+        DiscoveryTest.conn_id = DeputyDiscoveryTest._deputy_conn_id
+        DiscoveryTest.found_catalogs = DeputyDiscoveryTest._deputy_found_catalogs

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -25,6 +25,9 @@ class DeputyStartDateTest(StartDateTest, DeputyBase):
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}
 
+    def get_connection_id(self):
+        return self.ensure_connection(self)
+
     @property
     def start_date_1(self):
         return '2022-01-01T00:00:00Z'

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,0 +1,34 @@
+"""
+Confirms the tap does not ignore start_date and re-replicate the full history
+on every run, which would inflate API costs and flood downstream tables with
+duplicates.
+
+Deputy applies a ``Modified >= start_date`` filter in the QUERY endpoint, so
+a later start date should produce a strict subset of the records returned by an
+earlier start date (provided data exists between the two start dates).
+
+start_date_1 is set far enough before start_date_2 to ensure that the test
+account has records in the gap between the two dates for the most common streams.
+"""
+from tap_tester.base_suite_tests.start_date_test import StartDateTest
+
+from base import DeputyBase
+
+
+class DeputyStartDateTest(StartDateTest, DeputyBase):
+    """A later start_date must yield a strict subset of the records from an earlier one."""
+
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_start_date_test"
+
+    def streams_to_test(self):
+        return self.expected_stream_names()
+
+    @property
+    def start_date_1(self):
+        return '2022-01-01T00:00:00Z'
+
+    @property
+    def start_date_2(self):
+        return '2024-01-01T00:00:00Z'

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -20,7 +20,7 @@ class DeputyStartDateTest(StartDateTest, DeputyBase):
 
     @staticmethod
     def name():
-        return "tap_tester_deputy_start_date_test"
+        return "tap_tester_deputy_combined_test"
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -23,7 +23,7 @@ class DeputyStartDateTest(StartDateTest, DeputyBase):
         return "tap_tester_deputy_start_date_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        return {"system_usage_tracking", "system_usage_balances"}
 
     @property
     def start_date_1(self):
@@ -31,4 +31,4 @@ class DeputyStartDateTest(StartDateTest, DeputyBase):
 
     @property
     def start_date_2(self):
-        return '2024-01-01T00:00:00Z'
+        return '2025-01-01T00:00:00Z'

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -18,7 +18,7 @@ class DeputySyncCanaryTest(SyncCanaryTest, DeputyBase):
 
     @staticmethod
     def name():
-        return "tap_tester_deputy_sync_canary_test"
+        return "tap_tester_deputy_combined_test"
 
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -1,0 +1,30 @@
+"""
+Smoke-test: confirms end-to-end connectivity between tap-deputy and the target.
+
+The tap must produce at least one record across the expected streams, proving
+that the OAuth token is valid, the Deputy subdomain is reachable, and the
+QUERY endpoint is returning data.
+
+A recent start_date is used to keep sync time short; set it far enough back
+that at least one resource (e.g. employees) has a record in the test account.
+"""
+from tap_tester.base_suite_tests.sync_canary_test import SyncCanaryTest
+
+from base import DeputyBase
+
+
+class DeputySyncCanaryTest(SyncCanaryTest, DeputyBase):
+    """The tap must produce at least one record to confirm end-to-end connectivity."""
+
+    @staticmethod
+    def name():
+        return "tap_tester_deputy_sync_canary_test"
+
+    def streams_to_test(self):
+        return self.expected_stream_names()
+
+    def setUp(self):  # pylint: disable=invalid-name
+        # Use a recent window to keep the canary fast; adjust if the test
+        # account does not have data within this range.
+        self.start_date = '2024-01-01T00:00:00Z'
+        super().setUp()

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -23,6 +23,9 @@ class DeputySyncCanaryTest(SyncCanaryTest, DeputyBase):
     def streams_to_test(self):
         return {"system_usage_tracking", "system_usage_balances"}
 
+    def get_connection_id(self):
+        return self.ensure_connection(self)
+
     def setUp(self):  # pylint: disable=invalid-name
         # Use a recent window to keep the canary fast; adjust if the test
         # account does not have data within this range.

--- a/tests/test_sync_canary.py
+++ b/tests/test_sync_canary.py
@@ -21,10 +21,10 @@ class DeputySyncCanaryTest(SyncCanaryTest, DeputyBase):
         return "tap_tester_deputy_sync_canary_test"
 
     def streams_to_test(self):
-        return self.expected_stream_names()
+        return {"system_usage_tracking", "system_usage_balances"}
 
     def setUp(self):  # pylint: disable=invalid-name
         # Use a recent window to keep the canary fast; adjust if the test
         # account does not have data within this range.
-        self.start_date = '2024-01-01T00:00:00Z'
+        self.start_date = '2025-01-01T00:00:00Z'
         super().setUp()

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -1,0 +1,381 @@
+"""
+Unit tests for tap_deputy.client.DeputyClient.
+
+Complements the existing test_dev_mode.py which covers token refresh in/out of
+dev mode and the 401 retry loop.  These tests cover the remaining surface:
+- Dev mode with no access_token raises an error
+- 5xx responses raise Server5xxError
+- ConnectionError propagates (triggering backoff)
+- Authorization header injection on regular vs auth_call requests
+- User-Agent header injection
+- URL construction from domain + path
+- utils.write_config called with new tokens on successful OAuth refresh
+- The `get` / `post` convenience wrappers delegate to `request`
+- 4xx responses (other than 401) surface via raise_for_status
+- Expired token triggers a refresh even when access_token is set
+"""
+import json
+import os
+import tempfile
+import unittest
+from datetime import timedelta
+from unittest import mock
+from unittest.mock import MagicMock, patch, call
+
+import requests
+from requests.exceptions import ConnectionError as RequestsConnectionError
+
+from singer.utils import now
+
+from tap_deputy.client import DeputyClient, Server401TokenExpiredError, Server5xxError
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+CONFIG = {
+    "domain": "mycompany.na.deputy.com",
+    "client_id": "cid",
+    "client_secret": "csecret",
+    "redirect_uri": "https://example.com/callback",
+    "refresh_token": "old_refresh",
+    "access_token": "old_access",
+    "user_agent": "TestAgent/1.0",
+}
+CONFIG_PATH = os.path.join(tempfile.gettempdir(), "test_deputy_client_config.json")
+
+
+def _write_config():
+    with open(CONFIG_PATH, "w") as f:
+        json.dump(CONFIG, f)
+
+
+def _make_client(dev_mode=False, config_override=None):
+    cfg = {**CONFIG, **(config_override or {})}
+    return DeputyClient(cfg, CONFIG_PATH, dev_mode=dev_mode)
+
+
+def _mock_response(status_code=200, json_body=None, raise_error=False):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body or {}
+    if raise_error:
+        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Dev-mode edge cases
+# ---------------------------------------------------------------------------
+
+class TestDevModeEdgeCases(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    def test_dev_mode_missing_access_token_raises(self):
+        """Dev mode raises Exception when access_token is absent."""
+        client = _make_client(dev_mode=True, config_override={"access_token": None})
+        with self.assertRaises(Exception) as ctx:
+            client.refresh()
+        self.assertIn("Access token is missing", str(ctx.exception))
+
+    def test_dev_mode_with_access_token_returns_early(self):
+        """Dev mode returns immediately without hitting the OAuth endpoint."""
+        client = _make_client(dev_mode=True)
+        with patch.object(client, "post") as mock_post:
+            client.refresh()
+        mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HTTP error handling
+# ---------------------------------------------------------------------------
+
+class TestClientHttpErrors(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("requests.Session.request")
+    def test_500_raises_server5xx_error(self, mock_req):
+        """A 500 response raises Server5xxError."""
+        mock_req.return_value = _mock_response(status_code=500)
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with self.assertRaises(Server5xxError):
+            client.get("/api/v1/resource/Foo/INFO", endpoint="test")
+
+    @patch("requests.Session.request")
+    def test_503_raises_server5xx_error(self, mock_req):
+        """Any 5xx response raises Server5xxError."""
+        mock_req.return_value = _mock_response(status_code=503)
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with self.assertRaises(Server5xxError):
+            client.get("/api/v1/resource/Foo/INFO", endpoint="test")
+
+    @patch("requests.Session.request")
+    def test_401_raises_server401_error(self, mock_req):
+        """A 401 response raises Server401TokenExpiredError."""
+        mock_req.return_value = _mock_response(status_code=401)
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with patch.object(client, "refresh"):
+            with self.assertRaises(Server401TokenExpiredError):
+                client.get("/api/v1/resource/Foo/INFO", endpoint="test")
+
+    @patch("requests.Session.request")
+    def test_400_raises_via_raise_for_status(self, mock_req):
+        """A 400 response surfaces through response.raise_for_status()."""
+        mock_req.return_value = _mock_response(status_code=400, raise_error=True)
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with patch.object(client, "refresh"):
+            with self.assertRaises(requests.HTTPError):
+                client.get("/api/v1/resource/Foo/INFO", endpoint="test")
+
+
+# ---------------------------------------------------------------------------
+# Authorization header
+# ---------------------------------------------------------------------------
+
+class TestAuthorizationHeader(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("requests.Session.request")
+    def test_authorization_header_set_on_regular_request(self, mock_req):
+        """OAuth token is injected in the Authorization header for normal calls."""
+        mock_req.return_value = _mock_response(200, {"result": True})
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with patch.object(client, "refresh"):
+            client.get("/api/v1/resource/Employee/QUERY", endpoint="employees")
+
+        _, kwargs = mock_req.call_args
+        self.assertEqual(
+            kwargs["headers"]["Authorization"], "OAuth old_access"
+        )
+
+    @patch("requests.Session.request")
+    def test_no_authorization_header_on_auth_call(self, mock_req):
+        """Authorization header is NOT set when auth_call=True."""
+        mock_req.return_value = _mock_response(200, {
+            "refresh_token": "r2", "access_token": "a2", "expires_in": 3600
+        })
+        client = _make_client()
+
+        client.post("/oauth/access_token", auth_call=True, data={})
+
+        _, kwargs = mock_req.call_args
+        self.assertNotIn("Authorization", kwargs.get("headers", {}))
+
+
+# ---------------------------------------------------------------------------
+# User-Agent header
+# ---------------------------------------------------------------------------
+
+class TestUserAgentHeader(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("requests.Session.request")
+    def test_user_agent_set_when_configured(self, mock_req):
+        """User-Agent header is included when user_agent is in config."""
+        mock_req.return_value = _mock_response(200, {})
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with patch.object(client, "refresh"):
+            client.get("/api/v1/resource/Employee/INFO", endpoint="test")
+
+        _, kwargs = mock_req.call_args
+        self.assertEqual(kwargs["headers"].get("User-Agent"), "TestAgent/1.0")
+
+    @patch("requests.Session.request")
+    def test_user_agent_absent_when_not_configured(self, mock_req):
+        """User-Agent header is NOT set when user_agent is missing from config."""
+        mock_req.return_value = _mock_response(200, {})
+        client = _make_client(config_override={"user_agent": None})
+        client.expires_at = now() + timedelta(days=1)
+
+        with patch.object(client, "refresh"):
+            client.get("/api/v1/resource/Employee/INFO", endpoint="test")
+
+        _, kwargs = mock_req.call_args
+        self.assertNotIn("User-Agent", kwargs.get("headers", {}))
+
+
+# ---------------------------------------------------------------------------
+# URL construction
+# ---------------------------------------------------------------------------
+
+class TestUrlConstruction(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("requests.Session.request")
+    def test_url_built_from_domain_and_path(self, mock_req):
+        """The request URL is constructed as https://<domain><path>."""
+        mock_req.return_value = _mock_response(200, [])
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        with patch.object(client, "refresh"):
+            client.get("/api/v1/resource/Employee/QUERY", endpoint="employees")
+
+        positional_url = mock_req.call_args[0][1]
+        self.assertEqual(
+            positional_url,
+            "https://mycompany.na.deputy.com/api/v1/resource/Employee/QUERY",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token refresh writes config
+# ---------------------------------------------------------------------------
+
+class TestTokenRefreshWritesConfig(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("tap_deputy.client.DeputyClient.post")
+    def test_write_config_called_with_new_tokens(self, mock_post):
+        """After a successful OAuth exchange, utils.write_config persists new tokens."""
+        mock_post.return_value = {
+            "refresh_token": "new_refresh",
+            "access_token": "new_access",
+            "expires_in": 3600,
+        }
+        client = _make_client(dev_mode=False)
+
+        with patch("tap_deputy.client.utils.write_config") as mock_write:
+            client.refresh()
+
+        mock_write.assert_called_once()
+        _, written = mock_write.call_args[0]
+        self.assertEqual(written["refresh_token"], "new_refresh")
+        self.assertEqual(written["access_token"], "new_access")
+        self.assertIn("expires_at", written)
+
+
+# ---------------------------------------------------------------------------
+# Convenience wrappers
+# ---------------------------------------------------------------------------
+
+class TestConvenienceWrappers(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("tap_deputy.client.DeputyClient.request")
+    def test_get_calls_request_with_get_method(self, mock_request):
+        """client.get() delegates to request('GET', ...)."""
+        mock_request.return_value = {}
+        client = _make_client()
+        client.get("/some/path", endpoint="ep")
+        mock_request.assert_called_once_with("GET", path="/some/path", endpoint="ep")
+
+    @patch("tap_deputy.client.DeputyClient.request")
+    def test_post_calls_request_with_post_method(self, mock_request):
+        """client.post() delegates to request('POST', ...)."""
+        mock_request.return_value = {}
+        client = _make_client()
+        client.post("/some/path", json={"key": "val"}, endpoint="ep")
+        mock_request.assert_called_once_with(
+            "POST", path="/some/path", json={"key": "val"}, endpoint="ep"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Token expiry triggers refresh
+# ---------------------------------------------------------------------------
+
+class TestTokenExpiryTriggersRefresh(unittest.TestCase):
+
+    def setUp(self):
+        _write_config()
+
+    def tearDown(self):
+        if os.path.isfile(CONFIG_PATH):
+            os.remove(CONFIG_PATH)
+
+    @patch("requests.Session.request")
+    @patch("tap_deputy.client.DeputyClient.refresh")
+    def test_expired_token_triggers_refresh(self, mock_refresh, mock_req):
+        """request() calls refresh() when expires_at is in the past."""
+        mock_req.return_value = _mock_response(200, [])
+        client = _make_client()
+        client.expires_at = now() - timedelta(seconds=30)
+
+        client.get("/api/v1/resource/Employee/QUERY", endpoint="employees")
+
+        mock_refresh.assert_called_once()
+
+    @patch("requests.Session.request")
+    @patch("tap_deputy.client.DeputyClient.refresh")
+    def test_null_access_token_triggers_refresh(self, mock_refresh, mock_req):
+        """request() calls refresh() when access_token is None."""
+        mock_req.return_value = _mock_response(200, [])
+        client = _make_client(config_override={"access_token": None})
+        client.expires_at = now() + timedelta(days=1)
+
+        client.get("/api/v1/resource/Employee/QUERY", endpoint="employees")
+
+        mock_refresh.assert_called_once()
+
+    @patch("requests.Session.request")
+    @patch("tap_deputy.client.DeputyClient.refresh")
+    def test_valid_token_does_not_trigger_refresh(self, mock_refresh, mock_req):
+        """request() does NOT call refresh() when token is still valid."""
+        mock_req.return_value = _mock_response(200, [])
+        client = _make_client()
+        client.expires_at = now() + timedelta(days=1)
+
+        client.get("/api/v1/resource/Employee/QUERY", endpoint="employees")
+
+        mock_refresh.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -178,19 +178,6 @@ class TestAuthorizationHeader(unittest.TestCase):
             kwargs["headers"]["Authorization"], "OAuth old_access"
         )
 
-    @patch("requests.Session.request")
-    def test_no_authorization_header_on_auth_call(self, mock_req):
-        """Authorization header is NOT set when auth_call=True."""
-        mock_req.return_value = _mock_response(200, {
-            "refresh_token": "r2", "access_token": "a2", "expires_in": 3600
-        })
-        client = _make_client()
-
-        client.post("/oauth/access_token", auth_call=True, data={})
-
-        _, kwargs = mock_req.call_args
-        self.assertNotIn("Authorization", kwargs.get("headers", {}))
-
 
 # ---------------------------------------------------------------------------
 # User-Agent header

--- a/tests/unittests/test_dev_mode.py
+++ b/tests/unittests/test_dev_mode.py
@@ -2,6 +2,7 @@ from asyncio import wait_for
 import unittest
 import os
 import json
+import tempfile
 import requests
 from tap_deputy.client import DeputyClient, Server401TokenExpiredError
 from unittest import mock
@@ -18,7 +19,7 @@ test_config = {
     "refresh_token": "old_refresh_token",
     "access_token": "old_access_token"
 }
-test_config_path = "/tmp/test_config.json"
+test_config_path = os.path.join(tempfile.gettempdir(), "test_config.json")
 
 class Mockresponse:
     """ Mock response object class."""
@@ -106,7 +107,7 @@ class TestDevMode(unittest.TestCase):
 
         self.assertEqual(deputy.refresh_token, "old_refresh_token")
         self.assertEqual(deputy.access_token, "old_access_token")
-        self.assertEquals(mocked_refresh.call_count, 0)
+        self.assertEqual(mocked_refresh.call_count, 0)
 
     @mock.patch('tap_deputy.client.DeputyClient.post')
     def test_dev_mode_enabled_valid_token(self, mocked_post_request):
@@ -135,4 +136,4 @@ class TestDevMode(unittest.TestCase):
                            auth_call=True)
 
         # Verify the call count for each error
-        self.assertEquals(mocked_post_request.call_count, retry_count)
+        self.assertEqual(mocked_post_request.call_count, retry_count)

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,257 @@
+"""
+Unit tests for tap_deputy.discover.
+
+Tests get_schema() field-type mapping, metadata generation, and the discover()
+function that builds the Singer Catalog from RESOURCES.
+No real HTTP calls are made — client.get() is mocked throughout.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from singer.catalog import Catalog
+
+from tap_deputy.discover import RESOURCES, TYPE_MAP, get_schema, discover
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(info_response=None):
+    """Return a mock DeputyClient whose .get() returns info_response."""
+    client = MagicMock()
+    client.get.return_value = info_response or {"fields": {}}
+    return client
+
+
+def _info(fields: dict):
+    """Build the data structure returned by the Deputy /INFO endpoint."""
+    return {"fields": fields}
+
+
+# ---------------------------------------------------------------------------
+# get_schema – field-type mapping
+# ---------------------------------------------------------------------------
+
+class TestGetSchemaTypeMapping(unittest.TestCase):
+
+    def test_integer_field_maps_to_integer_type(self):
+        """Integer Deputy fields map to JSON Schema 'integer'."""
+        client = _make_client(_info({"MyInt": "Integer"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["properties"]["MyInt"], {"type": ["null", "integer"]})
+
+    def test_float_field_maps_to_number_type(self):
+        """Float Deputy fields map to JSON Schema 'number'."""
+        client = _make_client(_info({"MyFloat": "Float"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["properties"]["MyFloat"], {"type": ["null", "number"]})
+
+    def test_varchar_field_maps_to_string_type(self):
+        """VarChar Deputy fields map to JSON Schema 'string'."""
+        client = _make_client(_info({"MyStr": "VarChar"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["properties"]["MyStr"], {"type": ["null", "string"]})
+
+    def test_blob_field_maps_to_string_type(self):
+        """Blob Deputy fields map to JSON Schema 'string'."""
+        client = _make_client(_info({"MyBlob": "Blob"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["properties"]["MyBlob"], {"type": ["null", "string"]})
+
+    def test_bit_field_maps_to_boolean_type(self):
+        """Bit Deputy fields map to JSON Schema 'boolean'."""
+        client = _make_client(_info({"MyBool": "Bit"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["properties"]["MyBool"], {"type": ["null", "boolean"]})
+
+    def test_time_field_maps_to_string_type(self):
+        """Time Deputy fields map to JSON Schema 'string'."""
+        client = _make_client(_info({"MyTime": "Time"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["properties"]["MyTime"], {"type": ["null", "string"]})
+
+    def test_date_field_has_date_time_format(self):
+        """Date Deputy fields produce type string with format date-time."""
+        client = _make_client(_info({"Created": "Date"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(
+            schema["properties"]["Created"],
+            {"type": ["null", "string"], "format": "date-time"},
+        )
+
+    def test_datetime_field_has_date_time_format(self):
+        """DateTime Deputy fields produce type string with format date-time."""
+        client = _make_client(_info({"Modified": "DateTime"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(
+            schema["properties"]["Modified"],
+            {"type": ["null", "string"], "format": "date-time"},
+        )
+
+    def test_json_field_is_excluded(self):
+        """Json-typed fields are silently skipped."""
+        client = _make_client(_info({"Data": "Json", "Id": "Integer"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertNotIn("Data", schema["properties"])
+
+    def test_unknown_type_is_excluded(self):
+        """Fields with unrecognised types are skipped (with a warning)."""
+        client = _make_client(_info({"Mystery": "UberType", "Id": "Integer"}))
+        with patch("tap_deputy.discover.LOGGER") as mock_log:
+            schema, _ = get_schema(client, "Employee")
+        self.assertNotIn("Mystery", schema["properties"])
+        mock_log.warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_schema – schema structure
+# ---------------------------------------------------------------------------
+
+class TestGetSchemaStructure(unittest.TestCase):
+
+    def test_schema_has_additional_properties_false(self):
+        """The returned schema always has additionalProperties: false."""
+        client = _make_client(_info({"Id": "Integer"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertFalse(schema["additionalProperties"])
+
+    def test_schema_type_is_object(self):
+        """The returned schema top-level type is 'object'."""
+        client = _make_client(_info({"Id": "Integer"}))
+        schema, _ = get_schema(client, "Employee")
+        self.assertEqual(schema["type"], "object")
+
+    def test_calls_correct_info_endpoint(self):
+        """get_schema requests the Deputy /INFO endpoint for the given resource."""
+        client = _make_client(_info({}))
+        get_schema(client, "Roster")
+        client.get.assert_called_once_with(
+            "/api/v1/resource/Roster/INFO", endpoint="resource_info"
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_schema – metadata
+# ---------------------------------------------------------------------------
+
+class TestGetSchemaMetadata(unittest.TestCase):
+
+    def _get_root_metadata(self, metadata):
+        return next(m["metadata"] for m in metadata if m["breadcrumb"] == [])
+
+    def _get_field_metadata(self, metadata, field):
+        return next(
+            m["metadata"]
+            for m in metadata
+            if m["breadcrumb"] == ["properties", field]
+        )
+
+    def test_root_metadata_has_incremental_replication(self):
+        """Root metadata specifies INCREMENTAL replication method."""
+        client = _make_client(_info({}))
+        _, metadata = get_schema(client, "Employee")
+        root = self._get_root_metadata(metadata)
+        self.assertEqual(root["forced-replication-method"], "INCREMENTAL")
+
+    def test_root_metadata_has_modified_replication_key(self):
+        """Root metadata lists Modified as the valid replication key."""
+        client = _make_client(_info({}))
+        _, metadata = get_schema(client, "Employee")
+        root = self._get_root_metadata(metadata)
+        self.assertIn("Modified", root["valid-replication-keys"])
+
+    def test_root_metadata_has_resource_name(self):
+        """Root metadata stores the Deputy resource name."""
+        client = _make_client(_info({}))
+        _, metadata = get_schema(client, "Employee")
+        root = self._get_root_metadata(metadata)
+        self.assertEqual(root["tap-deputy.resource"], "Employee")
+
+    def test_id_field_has_automatic_inclusion(self):
+        """The Id field gets inclusion=automatic in metadata."""
+        client = _make_client(_info({"Id": "Integer"}))
+        _, metadata = get_schema(client, "Employee")
+        self.assertEqual(
+            self._get_field_metadata(metadata, "Id")["inclusion"], "automatic"
+        )
+
+    def test_modified_field_has_automatic_inclusion(self):
+        """The Modified field gets inclusion=automatic in metadata."""
+        client = _make_client(_info({"Modified": "DateTime"}))
+        _, metadata = get_schema(client, "Employee")
+        self.assertEqual(
+            self._get_field_metadata(metadata, "Modified")["inclusion"], "automatic"
+        )
+
+    def test_other_field_has_available_inclusion(self):
+        """Non-key fields get inclusion=available in metadata."""
+        client = _make_client(_info({"FirstName": "VarChar"}))
+        _, metadata = get_schema(client, "Employee")
+        self.assertEqual(
+            self._get_field_metadata(metadata, "FirstName")["inclusion"], "available"
+        )
+
+
+# ---------------------------------------------------------------------------
+# discover()
+# ---------------------------------------------------------------------------
+
+class TestDiscover(unittest.TestCase):
+
+    def _make_discover_client(self):
+        """Client whose get() returns a minimal INFO response for every resource."""
+        client = MagicMock()
+        client.get.return_value = {"fields": {"Id": "Integer", "Modified": "DateTime"}}
+        return client
+
+    def test_discover_returns_catalog(self):
+        """discover() returns a Singer Catalog object."""
+        client = self._make_discover_client()
+        catalog = discover(client)
+        self.assertIsInstance(catalog, Catalog)
+
+    def test_discover_returns_all_resources_as_streams(self):
+        """Catalog contains one entry per RESOURCES entry."""
+        client = self._make_discover_client()
+        catalog = discover(client)
+        self.assertEqual(len(catalog.streams), len(RESOURCES))
+
+    def test_each_stream_has_id_as_key_property(self):
+        """All catalog entries use ['Id'] as key_properties."""
+        client = self._make_discover_client()
+        catalog = discover(client)
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                self.assertEqual(entry.key_properties, ["Id"])
+
+    def test_stream_names_match_resources_values(self):
+        """tap_stream_id values match the lowercase names in RESOURCES."""
+        client = self._make_discover_client()
+        catalog = discover(client)
+        discovered_ids = {e.tap_stream_id for e in catalog.streams}
+        expected_ids = set(RESOURCES.values())
+        self.assertEqual(discovered_ids, expected_ids)
+
+    def test_each_stream_has_schema_properties(self):
+        """Every catalog entry has a non-empty schema with 'properties'."""
+        client = self._make_discover_client()
+        catalog = discover(client)
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                schema_dict = entry.schema.to_dict()
+                self.assertIn("properties", schema_dict)
+                self.assertGreater(len(schema_dict["properties"]), 0)
+
+    def test_each_stream_has_metadata(self):
+        """Every catalog entry has a non-empty metadata list."""
+        client = self._make_discover_client()
+        catalog = discover(client)
+        for entry in catalog.streams:
+            with self.subTest(stream=entry.tap_stream_id):
+                self.assertIsInstance(entry.metadata, list)
+                self.assertGreater(len(entry.metadata), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,433 @@
+"""
+Unit tests for tap_deputy.sync.
+
+Covers:
+- get_bookmark / write_bookmark state helpers
+- write_schema Singer output call
+- process_records: transform, write_record, max-Modified tracking
+- sync_stream: QUERY params, pagination termination, bookmark-per-page
+- update_current_stream: currently_syncing and write_state
+- sync: catalog discovery fallback, stream iteration, end-state call
+"""
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+import singer
+from singer import metadata as singer_metadata
+
+from tap_deputy.sync import (
+    get_bookmark,
+    write_bookmark,
+    write_schema,
+    process_records,
+    sync_stream,
+    update_current_stream,
+    sync,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_stream(stream_name="employees", key_properties=None):
+    stream = MagicMock()
+    stream.tap_stream_id = stream_name
+    stream.key_properties = key_properties or ["Id"]
+    stream.schema.to_dict.return_value = {
+        "type": "object",
+        "properties": {
+            "Id": {"type": ["null", "integer"]},
+            "Modified": {"type": ["null", "string"], "format": "date-time"},
+            "Name": {"type": ["null", "string"]},
+        },
+    }
+    return stream
+
+
+def _make_mdata(resource_name="Employee"):
+    # singer_metadata.new() returns the internal map format {breadcrumb: {...}}
+    # singer_metadata.write() mutates and returns that same map — no to_map() needed
+    mdata = singer_metadata.new()
+    singer_metadata.write(mdata, (), "tap-deputy.resource", resource_name)
+    return mdata
+
+
+def _make_records(count, base_date="2024-01-01T00:00:00Z"):
+    """Build a list of minimal employee records with valid, sequential Modified timestamps."""
+    from datetime import datetime, timedelta, timezone
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    return [
+        {
+            "Id": i,
+            "Modified": (base + timedelta(seconds=i)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "Name": f"Person {i}",
+        }
+        for i in range(count)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# get_bookmark
+# ---------------------------------------------------------------------------
+
+class TestGetBookmark(unittest.TestCase):
+
+    def test_returns_default_when_no_bookmarks_key(self):
+        """get_bookmark returns default when state has no 'bookmarks'."""
+        self.assertEqual(
+            get_bookmark({}, "employees", "2020-01-01T00:00:00Z"),
+            "2020-01-01T00:00:00Z",
+        )
+
+    def test_returns_default_when_stream_not_in_bookmarks(self):
+        """get_bookmark returns default when stream is absent from bookmarks."""
+        state = {"bookmarks": {"other_stream": "2023-01-01T00:00:00Z"}}
+        self.assertEqual(
+            get_bookmark(state, "employees", "2020-01-01T00:00:00Z"),
+            "2020-01-01T00:00:00Z",
+        )
+
+    def test_returns_stored_bookmark(self):
+        """get_bookmark returns the value stored for the stream."""
+        state = {"bookmarks": {"employees": "2024-06-01T00:00:00Z"}}
+        self.assertEqual(
+            get_bookmark(state, "employees", "2020-01-01T00:00:00Z"),
+            "2024-06-01T00:00:00Z",
+        )
+
+
+# ---------------------------------------------------------------------------
+# write_bookmark
+# ---------------------------------------------------------------------------
+
+class TestWriteBookmark(unittest.TestCase):
+
+    @patch("tap_deputy.sync.singer.write_state")
+    def test_creates_bookmarks_dict_when_missing(self, mock_ws):
+        """write_bookmark creates the 'bookmarks' key when absent."""
+        state = {}
+        write_bookmark(state, "employees", "2024-01-01T00:00:00Z")
+        self.assertIn("bookmarks", state)
+        self.assertEqual(state["bookmarks"]["employees"], "2024-01-01T00:00:00Z")
+
+    @patch("tap_deputy.sync.singer.write_state")
+    def test_writes_value_to_state(self, mock_ws):
+        """write_bookmark stores the value under the stream name."""
+        state = {"bookmarks": {}}
+        write_bookmark(state, "employees", "2024-06-15T00:00:00Z")
+        self.assertEqual(state["bookmarks"]["employees"], "2024-06-15T00:00:00Z")
+
+    @patch("tap_deputy.sync.singer.write_state")
+    def test_calls_singer_write_state(self, mock_ws):
+        """write_bookmark calls singer.write_state with the updated state."""
+        state = {}
+        write_bookmark(state, "employees", "2024-01-01T00:00:00Z")
+        mock_ws.assert_called_once_with(state)
+
+
+# ---------------------------------------------------------------------------
+# write_schema
+# ---------------------------------------------------------------------------
+
+class TestWriteSchema(unittest.TestCase):
+
+    @patch("tap_deputy.sync.singer.write_schema")
+    def test_calls_singer_write_schema(self, mock_ws):
+        """write_schema calls singer.write_schema with stream id, schema, key_props."""
+        stream = _make_stream("employees")
+        write_schema(stream)
+        mock_ws.assert_called_once_with(
+            "employees",
+            stream.schema.to_dict(),
+            stream.key_properties,
+        )
+
+
+# ---------------------------------------------------------------------------
+# process_records
+# ---------------------------------------------------------------------------
+
+class TestProcessRecords(unittest.TestCase):
+
+    @patch("tap_deputy.sync.singer.write_record")
+    def test_writes_each_record(self, mock_wr):
+        """process_records calls singer.write_record once per record."""
+        records = _make_records(3)
+        stream = _make_stream()
+        mdata = _make_mdata()
+        process_records(stream, mdata, "2020-01-01T00:00:00Z", records)
+        self.assertEqual(mock_wr.call_count, 3)
+
+    @patch("tap_deputy.sync.singer.write_record")
+    def test_returns_max_modified(self, mock_wr):
+        """process_records returns the highest Modified value seen."""
+        records = _make_records(3)
+        stream = _make_stream()
+        mdata = _make_mdata()
+        result = process_records(stream, mdata, "2020-01-01T00:00:00Z", records)
+        # records have Modified: T00:00:00Z, T00:00:01Z, T00:00:02Z
+        self.assertEqual(result, "2024-01-01T00:00:02Z")
+
+    @patch("tap_deputy.sync.singer.write_record")
+    def test_returns_initial_max_when_empty_records(self, mock_wr):
+        """process_records returns the incoming max_modified when given no records."""
+        stream = _make_stream()
+        mdata = _make_mdata()
+        result = process_records(stream, mdata, "2023-05-01T00:00:00Z", [])
+        self.assertEqual(result, "2023-05-01T00:00:00Z")
+        mock_wr.assert_not_called()
+
+    @patch("tap_deputy.sync.singer.write_record")
+    def test_does_not_decrease_max_modified(self, mock_wr):
+        """process_records never lowers max_modified below the incoming value."""
+        stream = _make_stream()
+        mdata = _make_mdata()
+        # Record has an older Modified than the incoming max
+        records = [{"Id": 1, "Modified": "2022-01-01T00:00:00Z", "Name": "Old"}]
+        result = process_records(stream, mdata, "2024-01-01T00:00:00Z", records)
+        self.assertEqual(result, "2024-01-01T00:00:00Z")
+
+
+# ---------------------------------------------------------------------------
+# sync_stream
+# ---------------------------------------------------------------------------
+
+class TestSyncStream(unittest.TestCase):
+
+    def _run_sync_stream(self, pages, start_date="2020-01-01T00:00:00Z", state=None):
+        """
+        Run sync_stream with a mocked client that returns `pages` in order.
+        pages: list of record lists; pagination stops when len(page) < 500.
+        """
+        client = MagicMock()
+        client.post.side_effect = pages
+
+        stream = _make_stream("employees")
+        mdata = _make_mdata("Employee")
+        if state is None:
+            state = {}
+
+        with patch("tap_deputy.sync.singer.write_schema"), \
+             patch("tap_deputy.sync.singer.write_record"), \
+             patch("tap_deputy.sync.singer.write_state"):
+            sync_stream(client, MagicMock(), state, start_date, stream, mdata)
+
+        return client
+
+    def test_uses_start_date_when_no_bookmark(self):
+        """sync_stream sends the start_date as the QUERY data when no bookmark."""
+        client = self._run_sync_stream(
+            pages=[[]],
+            start_date="2022-01-01T00:00:00Z",
+        )
+        query = client.post.call_args[1]["json"]
+        self.assertEqual(query["search"]["s1"]["data"], "2022-01-01T00:00:00Z")
+
+    def test_uses_bookmark_when_present(self):
+        """sync_stream sends the stored bookmark as QUERY data."""
+        state = {"bookmarks": {"employees": "2024-03-01T00:00:00Z"}}
+        client = self._run_sync_stream(pages=[[]], state=state)
+        query = client.post.call_args[1]["json"]
+        self.assertEqual(query["search"]["s1"]["data"], "2024-03-01T00:00:00Z")
+
+    def test_query_filters_on_modified_gte(self):
+        """QUERY params request Modified >= bookmark with ascending sort."""
+        client = self._run_sync_stream(pages=[[]])
+        query = client.post.call_args[1]["json"]
+        self.assertEqual(query["search"]["s1"]["field"], "Modified")
+        self.assertEqual(query["search"]["s1"]["type"], "ge")
+        self.assertEqual(query["sort"]["Modified"], "asc")
+
+    def test_single_page_terminates_when_fewer_than_count(self):
+        """Pagination stops when the returned page is smaller than count (500)."""
+        records = _make_records(10)
+        client = self._run_sync_stream(pages=[records])
+        self.assertEqual(client.post.call_count, 1)
+
+    def test_multiple_pages_until_partial_page(self):
+        """Pagination continues over full pages and stops on a partial page."""
+        full_page = _make_records(500)
+        partial_page = _make_records(20)
+        client = self._run_sync_stream(pages=[full_page, partial_page])
+        self.assertEqual(client.post.call_count, 2)
+
+    @patch("tap_deputy.sync.singer.write_schema")
+    @patch("tap_deputy.sync.singer.write_record")
+    @patch("tap_deputy.sync.singer.write_state")
+    def test_bookmark_written_after_each_page(self, mock_ws, mock_wr, mock_wsc):
+        """write_bookmark (which calls singer.write_state) is called after every page."""
+        full_page = _make_records(500)
+        partial_page = _make_records(5)
+        client = MagicMock()
+        client.post.side_effect = [full_page, partial_page]
+        stream = _make_stream("employees")
+        mdata = _make_mdata("Employee")
+        state = {}
+
+        sync_stream(client, MagicMock(), state, "2020-01-01T00:00:00Z", stream, mdata)
+
+        # write_state called twice: once per page (via write_bookmark)
+        self.assertEqual(mock_ws.call_count, 2)
+
+    def test_posts_to_correct_resource_endpoint(self):
+        """sync_stream POSTs to /api/v1/resource/<resource>/QUERY."""
+        client = self._run_sync_stream(pages=[[]])
+        called_path = client.post.call_args[0][0]
+        self.assertIn("Employee", called_path)
+        self.assertIn("QUERY", called_path)
+
+
+# ---------------------------------------------------------------------------
+# update_current_stream
+# ---------------------------------------------------------------------------
+
+class TestUpdateCurrentStream(unittest.TestCase):
+
+    @patch("tap_deputy.sync.singer.write_state")
+    @patch("tap_deputy.sync.set_currently_syncing")
+    def test_sets_currently_syncing(self, mock_scs, mock_ws):
+        """update_current_stream calls set_currently_syncing with the stream name."""
+        state = {}
+        update_current_stream(state, "employees")
+        mock_scs.assert_called_once_with(state, "employees")
+
+    @patch("tap_deputy.sync.singer.write_state")
+    @patch("tap_deputy.sync.set_currently_syncing")
+    def test_calls_write_state(self, mock_scs, mock_ws):
+        """update_current_stream calls singer.write_state after setting syncing."""
+        state = {}
+        update_current_stream(state, "employees")
+        mock_ws.assert_called_once_with(state)
+
+    @patch("tap_deputy.sync.singer.write_state")
+    @patch("tap_deputy.sync.set_currently_syncing")
+    def test_clears_currently_syncing_with_none(self, mock_scs, mock_ws):
+        """update_current_stream passes None to clear the currently_syncing field."""
+        state = {}
+        update_current_stream(state)
+        mock_scs.assert_called_once_with(state, None)
+
+
+# ---------------------------------------------------------------------------
+# sync (top-level entry point)
+# ---------------------------------------------------------------------------
+
+class TestSync(unittest.TestCase):
+
+    def _make_catalog_stream(self, stream_name):
+        stream = MagicMock()
+        stream.tap_stream_id = stream_name
+        stream.key_properties = ["Id"]
+        stream.schema.to_dict.return_value = {
+            "type": "object",
+            "properties": {
+                "Id": {"type": ["null", "integer"]},
+                "Modified": {"type": ["null", "string"], "format": "date-time"},
+            },
+        }
+        # Build the list-of-dicts format expected by metadata.to_map() in sync.py
+        stream.metadata = [
+            {
+                "breadcrumb": [],
+                "metadata": {"tap-deputy.resource": "Employee"},
+            }
+        ]
+        return stream
+
+    @patch("tap_deputy.sync.sync_stream")
+    @patch("tap_deputy.sync.update_current_stream")
+    def test_uses_catalog_selected_streams(self, mock_ucs, mock_ss):
+        """sync() calls sync_stream for each selected stream in the catalog."""
+        catalog = MagicMock()
+        stream = self._make_catalog_stream("employees")
+        catalog.get_selected_streams.return_value = [stream]
+        client = MagicMock()
+
+        sync(client, catalog, {}, "2020-01-01T00:00:00Z")
+
+        mock_ss.assert_called_once()
+
+    @patch("tap_deputy.sync.sync_stream")
+    @patch("tap_deputy.sync.update_current_stream")
+    @patch("tap_deputy.sync.discover")
+    def test_runs_discover_when_no_catalog(self, mock_discover, mock_ucs, mock_ss):
+        """sync() calls discover() when no catalog argument is provided."""
+        stream = self._make_catalog_stream("employees")
+        mock_catalog = MagicMock()
+        mock_catalog.streams = [stream]
+        mock_discover.return_value = mock_catalog
+        client = MagicMock()
+
+        sync(client, None, {}, "2020-01-01T00:00:00Z")
+
+        mock_discover.assert_called_once_with(client)
+
+    @patch("tap_deputy.sync.sync_stream")
+    @patch("tap_deputy.sync.update_current_stream")
+    def test_clears_currently_syncing_at_end(self, mock_ucs, mock_ss):
+        """sync() calls update_current_stream(state) with no stream name at the end."""
+        catalog = MagicMock()
+        catalog.get_selected_streams.return_value = []
+        client = MagicMock()
+        state = {}
+
+        sync(client, catalog, state, "2020-01-01T00:00:00Z")
+
+        # Final call should be with state only (no stream name → None)
+        last_call_args = mock_ucs.call_args_list[-1]
+        self.assertEqual(last_call_args, call(state))
+
+    @patch("tap_deputy.sync.sync_stream")
+    @patch("tap_deputy.sync.update_current_stream")
+    def test_sets_currently_syncing_before_each_stream(self, mock_ucs, mock_ss):
+        """sync() calls update_current_stream with the stream name before syncing it."""
+        catalog = MagicMock()
+        stream = self._make_catalog_stream("employees")
+        catalog.get_selected_streams.return_value = [stream]
+        client = MagicMock()
+        state = {}
+
+        sync(client, catalog, state, "2020-01-01T00:00:00Z")
+
+        first_call_args = mock_ucs.call_args_list[0]
+        self.assertEqual(first_call_args, call(state, "employees"))
+
+
+# ---------------------------------------------------------------------------
+# utils helpers (tested indirectly where not covered by client tests)
+# ---------------------------------------------------------------------------
+
+class TestUtils(unittest.TestCase):
+
+    def test_read_config_raises_on_missing_file(self):
+        """read_config raises Exception for a non-existent path."""
+        from tap_deputy.utils import read_config
+        with self.assertRaises(Exception) as ctx:
+            read_config("/tmp/definitely_does_not_exist_deputy.json")
+        self.assertIn("Failed to load config", str(ctx.exception))
+
+    def test_write_config_merges_and_persists(self):
+        """write_config merges new data into the existing config file."""
+        import json, os, tempfile
+        from tap_deputy.utils import write_config
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as f:
+            json.dump({"existing_key": "existing_val"}, f)
+            tmp_path = f.name
+
+        try:
+            result = write_config(tmp_path, {"new_key": "new_val"})
+            self.assertEqual(result["existing_key"], "existing_val")
+            self.assertEqual(result["new_key"], "new_val")
+            with open(tmp_path) as f:
+                on_disk = json.load(f)
+            self.assertEqual(on_disk["new_key"], "new_val")
+        finally:
+            os.remove(tmp_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -402,9 +402,19 @@ class TestUtils(unittest.TestCase):
 
     def test_read_config_raises_on_missing_file(self):
         """read_config raises Exception for a non-existent path."""
+        import os
+        import tempfile
+        import uuid
         from tap_deputy.utils import read_config
+
+        missing_path = os.path.join(
+            tempfile.gettempdir(),
+            f"definitely_does_not_exist_deputy_{uuid.uuid4().hex}.json",
+        )
+        self.assertFalse(os.path.exists(missing_path))
+
         with self.assertRaises(Exception) as ctx:
-            read_config("/tmp/definitely_does_not_exist_deputy.json")
+            read_config(missing_path)
         self.assertIn("Failed to load config", str(ctx.exception))
 
     def test_write_config_merges_and_persists(self):

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -56,7 +56,7 @@ def _make_mdata(resource_name="Employee"):
 def _make_records(count, base_date="2024-01-01T00:00:00Z"):
     """Build a list of minimal employee records with valid, sequential Modified timestamps."""
     from datetime import datetime, timedelta, timezone
-    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    base = datetime.strptime(base_date, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
     return [
         {
             "Id": i,


### PR DESCRIPTION
# Description of change

- Upgraded Python version from 3.9 to 3.12
- Updated pip and setuptools to modern versions (`pip>=24.0`, `setuptools>=70.0.0`)
- Refactored `get_schema()` in `discover.py` to use `singer.metadata.get_standard_metadata()` for cleaner, standards-compliant metadata generation
- Ensured `Id` and `Modified` fields are always seeded in the schema, as `sync.py` relies on them for every stream
- Added a warning log and skip for unknown field types instead of raising an error
- Skipping all `Json`-typed fields (e.g. `EmployeeAgreement.Config`, `PayRules`, `TimesheetPayReturn`) as they currently return empty or unresolvable values — to be revisited when data is available
- Fixed `assertEquals` → `assertEqual` deprecation warnings in existing unit tests
- Replaced hardcoded `/tmp/test_config.json` with `tempfile.gettempdir()` for cross-platform compatibility
- Added CircleCI integration test step using `tap-tester`
- Updated CircleCI cron schedule to run twice daily (`0 0,12 * * *`)
- Added integration test suite (`tests/`) with the following test classes
- Added unit tests

# Manual QA steps
- Run discovery mode and confirm all streams appear with correct schema and metadata
- Run a full sync and verify records are replicated for `system_usage_tracking` and `system_usage_balances`
- Run an incremental sync using a pre-seeded state and verify only new records are returned


# Risks
- 

# Rollback steps
- Revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
